### PR TITLE
Add custom modes in alarm mode

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -107,6 +107,9 @@ export enum ParamType {
 export enum AlarmMode {
     AWAY = 0,
     HOME = 1,
+    CUSTOM1 = 3,
+    CUSTOM2 = 4,
+    CUSTOM3 = 5,
     DISARMED = 63
 }
 
@@ -2258,6 +2261,9 @@ export const StationCurrentModeProperty: PropertyMetadataNumeric = {
     states: {
         0: "AWAY",
         1: "HOME",
+        3: "CUSTOM1",
+        4: "CUSTOM2",
+        5: "CUSTOM3",
         63: "DISARMED",
     },
 }


### PR DESCRIPTION
Alarm mode was undefined when setting custom_1, custom_2, custom_3 guard mode.
Alarm mode can take `CUSTOM_1`, `CUSTOM_2` and `CUSTOM_3` value after some api tests.

logs in `eufy-security-ws`
```
2021-07-18 18:03:59.846  INFO Alarm mode for station T8010Nxxxxxxxx changed to: HOME 
2021-07-18 18:04:02.414  INFO Alarm mode for station T8010Nxxxxxxxx changed to: undefined 
2021-07-18 18:04:05.043  INFO Alarm mode for station T8010Nxxxxxxxx changed to: HOME 
2021-07-18 18:04:07.872  INFO Alarm mode for station T8010Nxxxxxxxx changed to: undefined 
```
This should fix the issue.