### PR TITLE
Github Actions for npm release

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -1,0 +1,19 @@
+name: npm release
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The Github Actions build and publish to npm.
The trigger is "when a release is created on Github". Maybe you prefer on git tag ? As you want 🙂