### PR TITLE
Emit when indoor camera raise an alert after motion detected

### DIFF
--- a/src/p2p/interfaces.ts
+++ b/src/p2p/interfaces.ts
@@ -25,6 +25,7 @@ export interface P2PClientProtocolEvents {
     "rtsp livestream started": (channel: number) => void;
     "rtsp livestream stopped": (channel: number) => void;
     "floodlight manual switch": (channel: number, enabled: boolean) => void;
+    "indoor camera alarm": (data: string) => void;
 }
 
 export interface P2PQueueMessage {

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1374,6 +1374,14 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                     this.log.error(`Station ${this.rawStation.station_sn} - CMD_NOTIFY_PAYLOAD Error:`, { error: error, payload: message.data.toString() });
                 }
                 break;
+            case CommandType.CMD_SET_TONE_FILE:
+                try {
+                    this.log.debug(`Station ${this.rawStation.station_sn} - CMD_SET_TONE_FILE :`, { payload: message.data.toString("hex") });
+                    this.emit("indoor camera alarm", message.data.toString("hex"));
+                } catch (error) {
+                    this.log.error(`Station ${this.rawStation.station_sn} - CMD_SET_TONE_FILE - Error:`, { error: error, payload: message.data.toString("hex") });
+                }
+                break;
             case CommandType.CMD_PING:
                 // Ignore
                 break;


### PR DESCRIPTION
Looks like indoor camera will raise alarm not from station but itself.

I don't see any push generated when alarm is raised only push motion are.