### PR TITLE
fix: feature talkback

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -5041,7 +5041,7 @@ export class Station extends TypedEmitter<StationEvents> {
         if (device.getStationSerial() !== this.getSerial()) {
             throw new WrongStationError(`Device ${device.getSerial()} is not managed by this station ${this.getSerial()}`);
         }
-        if (!this.hasCommand(CommandName.DeviceStartTalkback)) {
+        if (!device.hasCommand(CommandName.DeviceStartTalkback)) {
             throw new NotSupportedError(`This functionality is not implemented or supported by ${device.getSerial()}`);
         }
         if (!this.isLiveStreaming(device)) {
@@ -5069,7 +5069,7 @@ export class Station extends TypedEmitter<StationEvents> {
         if (device.getStationSerial() !== this.getSerial()) {
             throw new WrongStationError(`Device ${device.getSerial()} is not managed by this station ${this.getSerial()}`);
         }
-        if (!this.hasCommand(CommandName.DeviceStopTalkback)) {
+        if (!device.hasCommand(CommandName.DeviceStopTalkback)) {
             throw new NotSupportedError(`This functionality is not implemented or supported by ${device.getSerial()}`);
         }
         if (!this.isLiveStreaming(device)) {

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1039,8 +1039,8 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                                 this.waitForStreamData(P2PDataType.BINARY);
                             } else if (msg_state.commandType === CommandType.CMD_START_TALKBACK || (msg_state.commandType === CommandType.CMD_DOORBELL_SET_PAYLOAD && msg_state.nestedCommandType === IndoorSoloSmartdropCommandType.CMD_START_SPEAK)) {
                                 if (return_code === ErrorCode.ERROR_PPCS_SUCCESSFUL) {
-                                    this.currentMessageState[message.dataType].p2pTalkback = true;
-                                    this.currentMessageState[message.dataType].p2pTalkbackChannel = msg_state.channel;
+                                    this.currentMessageState[P2PDataType.VIDEO].p2pTalkback = true;
+                                    this.currentMessageState[P2PDataType.VIDEO].p2pTalkbackChannel = msg_state.channel;
                                     this.talkbackStream.startTalkback();
                                     this.emit("talkback started", msg_state.channel, this.talkbackStream);
                                 } else if (return_code === ErrorCode.ERROR_NOT_FIND_DEV) {
@@ -1051,8 +1051,8 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                                     this.emit("talkback error", msg_state.channel, new TalkbackError(`Station ${this.rawStation.station_sn} channel ${msg_state.channel} connect failed please try again later.`));
                                 }
                             } else if (msg_state.commandType === CommandType.CMD_STOP_TALKBACK || (msg_state.commandType === CommandType.CMD_DOORBELL_SET_PAYLOAD && msg_state.nestedCommandType === IndoorSoloSmartdropCommandType.CMD_END_SPEAK)) {
-                                this.currentMessageState[message.dataType].p2pTalkback = false;
-                                this.currentMessageState[message.dataType].p2pTalkbackChannel = -1;
+                                this.currentMessageState[P2PDataType.VIDEO].p2pTalkback = false;
+                                this.currentMessageState[P2PDataType.VIDEO].p2pTalkbackChannel = -1;
                                 this.talkbackStream.stopTalkback();
                                 this.emit("talkback stopped", msg_state.channel);
                             }
@@ -1744,7 +1744,6 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
 
     private sendTalkbackAudioFrame(audioData: Buffer): void {
         //TODO: Pass channel information to buildTalkbackAudioFrameHeader
-        this.videoSeqNumber = this._incrementSequence(this.videoSeqNumber);
         const messageHeader = buildCommandHeader(this.videoSeqNumber, CommandType.CMD_AUDIO_FRAME, P2PDataTypeHeader.VIDEO);
         const messageAudioHeader = buildTalkbackAudioFrameHeader(audioData);
         const messageData = Buffer.concat([messageHeader, messageAudioHeader, audioData]);
@@ -1756,6 +1755,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
             retries: 0
         };
 
+        this.videoSeqNumber = this._incrementSequence(this.videoSeqNumber);
         this._sendVideoData(message);
     }
 


### PR DESCRIPTION
Hey @bropat 

with a few fixes talkback works great for me:

- sequence number has to start with value 0, otherwise no audio data will be played by doorbell
- there was a logical bug where the library checked whether the station has the talkback command instead of checking for the device
- the whole talkback feature uses VIDEO-frames but the control messages are DATA-frames. Therefore the `p2pTalkback` and `p2pTalkbackChannel` settings are stored in the wrong messageState