### PR TITLE
Dont respond to alarm push events for Homebase 2

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -401,7 +401,7 @@ export class Station extends TypedEmitter<StationEvents> {
                 } catch (error) {
                     this.log.debug(`Station ${message.station_sn} MODE_SWITCH event (${message.event_type}) - Error:`, error);
                 }
-            } else if (message.event_type === CusPushEvent.ALARM && message.station_sn === this.getSerial()) {
+            } else if (message.event_type === CusPushEvent.ALARM && message.station_sn === this.getSerial() && !this.isStation) {
                 this.log.info("Received push notification for alarm event", { stationSN: message.station_sn, alarmType: message.alarm_type });
                 if (message.alarm_type !== undefined)
                     this.emit("alarm event", this, message.alarm_type);

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -401,7 +401,7 @@ export class Station extends TypedEmitter<StationEvents> {
                 } catch (error) {
                     this.log.debug(`Station ${message.station_sn} MODE_SWITCH event (${message.event_type}) - Error:`, error);
                 }
-            } else if (message.event_type === CusPushEvent.ALARM && message.station_sn === this.getSerial() && !this.isStation) {
+            } else if (message.event_type === CusPushEvent.ALARM && message.station_sn === this.getSerial() && !this.isStation()) {
                 this.log.info("Received push notification for alarm event", { stationSN: message.station_sn, alarmType: message.alarm_type });
                 if (message.alarm_type !== undefined)
                     this.emit("alarm event", this, message.alarm_type);


### PR DESCRIPTION
As the Homebase 2 device (devic type 0) already listens for alarm events passed through the p2p connection, there is no need to listen to push data anymore.
This change excludes the Homebase 2 from emitting alarm events coming from push data.