### PR TITLE
Don't send the alarm armed p2p events as alarm events

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1432,8 +1432,9 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                     const alarmEventNumber = message.data.slice(0, 4).readUInt32LE();
                     if (alarmEventNumber === 0 || alarmEventNumber === 1) {
                         this.emit("alarm armed");
+                    } else {
+                        this.emit("alarm event", alarmEventNumber as AlarmEvent);
                     }
-                    this.emit("alarm event", alarmEventNumber as AlarmEvent);
                 } catch (error) {
                     this.log.error(`Station ${this.rawStation.station_sn} - CMD_SET_TONE_FILE - Error:`, { error: error, payload: message.data.toString("hex") });
                 }


### PR DESCRIPTION
I'm not really sure about this one.
I have never seen an alarm event from the push data with event numbers 0 and 1. They seem reserved for other purposes and not push data.
Now when I look at the events I effectively get an "alarm turned off" event when the alarm is armed, which is incorrect as there never was any alarm active.

This logic shouldn't bite the T8410 events mentioned in this PR: https://github.com/bropat/eufy-security-client/pull/151.
I have seen in the logging that it does not broadcast this alarm event when switching to an alarm enabled guard mode.

So judging by the data I see in the logging and what looks logical, I'd suggest _either_ emit an `alarm event` _or_ `alarm armed` event, not both.