### PR TITLE
Fix: stream command for T8420

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -2902,8 +2902,7 @@ export class Station extends TypedEmitter<StationEvents> {
                 }),
                 channel: device.getChannel()
             });
-        } else if (device.isWiredDoorbell() || (device.isFloodLight() && device.getDeviceType() !== DeviceType.FLOODLIGHT) || device.isIndoorCamera()) {
-            //TODO: T8420 should send this command
+        } else if (device.isWiredDoorbell() || (device.isFloodLight() && device.getDeviceType() !== DeviceType.FLOODLIGHT) || device.isIndoorCamera() || device.getSerial().startsWith("T8420")) {
             this.log.debug(`Using CMD_DOORBELL_SET_PAYLOAD for station ${this.getSerial()} (main_sw_version: ${this.getSoftwareVersion()})`);
             await this.p2pSession.sendCommandWithStringPayload({
                 commandType: CommandType.CMD_DOORBELL_SET_PAYLOAD,


### PR DESCRIPTION
Starting a local livestream on Floodlight (T8420) fails due to wrong command used.

See [here](https://github.com/homebridge-eufy-security/plugin/issues/72) for reference.

This fixes this (tested), but could be the wrong approach.

I added the specific check for the serial since I don't know if all DeviceType.FLOODLIGHT are T8420 devices. If so a simple change from `!==` to `===` would suffice of course.