### PR TITLE
Dual Doorbell Family names

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1048,7 +1048,7 @@ export class Camera extends Device {
 
         this.properties[PropertyName.DeviceMotionDetected] = false ;
         this.properties[PropertyName.DevicePersonDetected] = false ;
-        this.properties[PropertyName.DevicePersonName] = "";
+        this.properties[PropertyName.DevicePeopleNames] = "";
     }
 
     static async initialize(api: HTTPApi, device: DeviceListResponse): Promise<Camera> {
@@ -1233,7 +1233,7 @@ export class Camera extends Device {
     }
 
     public getDetectedPerson(): string {
-        return this.getPropertyValue(PropertyName.DevicePersonName) as string;
+        return this.getPropertyValue(PropertyName.DevicePeopleNames) as string;
     }
 
     public processPushNotification(message: PushMessage, eventDurationSeconds: number): void {
@@ -1244,17 +1244,17 @@ export class Camera extends Device {
                     if (message.fetch_id !== undefined) {
                         // Person or someone identified
                         this.updateProperty(PropertyName.DevicePersonDetected, true);
-                        this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
+                        this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
                         if (!isEmpty(message.pic_url))
                             this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                         if (message.push_count === 1 || message.push_count === undefined)
-                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
 
                         this.clearEventTimeout(DeviceEvent.PersonDetected);
                         this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                             this.updateProperty(PropertyName.DevicePersonDetected, false);
-                            this.updateProperty(PropertyName.DevicePersonName, "");
-                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                            this.updateProperty(PropertyName.DevicePeopleNames, "");
+                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
                             this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                         }, eventDurationSeconds * 1000));
                     } else {
@@ -1317,16 +1317,16 @@ export class SoloCamera extends Camera {
                             break;
                         case IndoorPushEvent.FACE_DETECTION:
                             this.updateProperty(PropertyName.DevicePersonDetected, true);
-                            this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
+                            this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
                             if (!isEmpty(message.pic_url))
                                 this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                             if (message.push_count === 1 || message.push_count === undefined)
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
                             this.clearEventTimeout(DeviceEvent.PersonDetected);
                             this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                                 this.updateProperty(PropertyName.DevicePersonDetected, false);
-                                this.updateProperty(PropertyName.DevicePersonName, "");
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                                this.updateProperty(PropertyName.DevicePeopleNames, "");
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
                                 this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                             }, eventDurationSeconds * 1000));
                             break;
@@ -1408,16 +1408,16 @@ export class IndoorCamera extends Camera {
                             break;
                         case IndoorPushEvent.FACE_DETECTION:
                             this.updateProperty(PropertyName.DevicePersonDetected, true);
-                            this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
+                            this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
                             if (!isEmpty(message.pic_url))
                                 this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                             if (message.push_count === 1 || message.push_count === undefined)
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
                             this.clearEventTimeout(DeviceEvent.PersonDetected);
                             this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                                 this.updateProperty(PropertyName.DevicePersonDetected, false);
-                                this.updateProperty(PropertyName.DevicePersonName, "");
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                                this.updateProperty(PropertyName.DevicePeopleNames, "");
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
                                 this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                             }, eventDurationSeconds * 1000));
                             break;
@@ -1544,16 +1544,17 @@ export class DoorbellCamera extends Camera {
                             }, eventDurationSeconds * 1000));
                             break;
                         case DoorbellPushEvent.FACE_DETECTION:
+                        case DoorbellPushEvent.FAMILY_DETECTION:
                             this.updateProperty(PropertyName.DevicePersonDetected, true);
-                            this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
+                            this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
                             if (!isEmpty(message.pic_url))
                                 this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                             if (message.push_count === 1 || message.push_count === undefined)
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
                             this.clearEventTimeout(DeviceEvent.PersonDetected);
                             this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                                 this.updateProperty(PropertyName.DevicePersonDetected, false);
-                                this.updateProperty(PropertyName.DevicePersonName, "");
+                                this.updateProperty(PropertyName.DevicePeopleNames, "");
                                 this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                             }, eventDurationSeconds * 1000));
                             break;

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1048,7 +1048,7 @@ export class Camera extends Device {
 
         this.properties[PropertyName.DeviceMotionDetected] = false ;
         this.properties[PropertyName.DevicePersonDetected] = false ;
-        this.properties[PropertyName.DevicePeopleNames] = "";
+        this.properties[PropertyName.DevicePersonName] = "";
     }
 
     static async initialize(api: HTTPApi, device: DeviceListResponse): Promise<Camera> {
@@ -1233,7 +1233,7 @@ export class Camera extends Device {
     }
 
     public getDetectedPerson(): string {
-        return this.getPropertyValue(PropertyName.DevicePeopleNames) as string;
+        return this.getPropertyValue(PropertyName.DevicePersonName) as string;
     }
 
     public processPushNotification(message: PushMessage, eventDurationSeconds: number): void {
@@ -1244,17 +1244,17 @@ export class Camera extends Device {
                     if (message.fetch_id !== undefined) {
                         // Person or someone identified
                         this.updateProperty(PropertyName.DevicePersonDetected, true);
-                        this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
+                        this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
                         if (!isEmpty(message.pic_url))
                             this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                         if (message.push_count === 1 || message.push_count === undefined)
-                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
 
                         this.clearEventTimeout(DeviceEvent.PersonDetected);
                         this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                             this.updateProperty(PropertyName.DevicePersonDetected, false);
-                            this.updateProperty(PropertyName.DevicePeopleNames, "");
-                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                            this.updateProperty(PropertyName.DevicePersonName, "");
+                            this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
                             this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                         }, eventDurationSeconds * 1000));
                     } else {
@@ -1317,16 +1317,16 @@ export class SoloCamera extends Camera {
                             break;
                         case IndoorPushEvent.FACE_DETECTION:
                             this.updateProperty(PropertyName.DevicePersonDetected, true);
-                            this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
+                            this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
                             if (!isEmpty(message.pic_url))
                                 this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                             if (message.push_count === 1 || message.push_count === undefined)
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
                             this.clearEventTimeout(DeviceEvent.PersonDetected);
                             this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                                 this.updateProperty(PropertyName.DevicePersonDetected, false);
-                                this.updateProperty(PropertyName.DevicePeopleNames, "");
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                                this.updateProperty(PropertyName.DevicePersonName, "");
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
                                 this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                             }, eventDurationSeconds * 1000));
                             break;
@@ -1408,16 +1408,16 @@ export class IndoorCamera extends Camera {
                             break;
                         case IndoorPushEvent.FACE_DETECTION:
                             this.updateProperty(PropertyName.DevicePersonDetected, true);
-                            this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
+                            this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
                             if (!isEmpty(message.pic_url))
                                 this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                             if (message.push_count === 1 || message.push_count === undefined)
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
                             this.clearEventTimeout(DeviceEvent.PersonDetected);
                             this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                                 this.updateProperty(PropertyName.DevicePersonDetected, false);
-                                this.updateProperty(PropertyName.DevicePeopleNames, "");
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                                this.updateProperty(PropertyName.DevicePersonName, "");
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
                                 this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                             }, eventDurationSeconds * 1000));
                             break;
@@ -1546,15 +1546,15 @@ export class DoorbellCamera extends Camera {
                         case DoorbellPushEvent.FACE_DETECTION:
                         case DoorbellPushEvent.FAMILY_DETECTION:
                             this.updateProperty(PropertyName.DevicePersonDetected, true);
-                            this.updateProperty(PropertyName.DevicePeopleNames, !isEmpty(message.people_names) ? message.people_names! : "Unknown");
+                            this.updateProperty(PropertyName.DevicePersonName, !isEmpty(message.person_name) ? message.person_name! : "Unknown");
                             if (!isEmpty(message.pic_url))
                                 this.updateProperty(PropertyName.DevicePictureUrl, message.pic_url!);
                             if (message.push_count === 1 || message.push_count === undefined)
-                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePeopleNames) as string);
+                                this.emit("person detected", this, this.getPropertyValue(PropertyName.DevicePersonDetected) as boolean, this.getPropertyValue(PropertyName.DevicePersonName) as string);
                             this.clearEventTimeout(DeviceEvent.PersonDetected);
                             this.eventTimeouts.set(DeviceEvent.PersonDetected, setTimeout(async () => {
                                 this.updateProperty(PropertyName.DevicePersonDetected, false);
-                                this.updateProperty(PropertyName.DevicePeopleNames, "");
+                                this.updateProperty(PropertyName.DevicePersonName, "");
                                 this.eventTimeouts.delete(DeviceEvent.PersonDetected);
                             }, eventDurationSeconds * 1000));
                             break;

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -325,7 +325,7 @@ export enum PropertyName {
     DeviceMotionAutoCruise = "motionAutoCruise",  // Flooglight T8423
     DeviceMotionOutOfViewDetection = "motionOutOfViewDetection",  // Flooglight T8423
     DevicePersonDetected = "personDetected",
-    DevicePeopleNames = "peopleNames",
+    DevicePersonName = "personName",
     DeviceRTSPStream = "rtspStream",
     DeviceRTSPStreamUrl = "rtspStreamUrl",
     DeviceWatermark = "watermark",

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -325,7 +325,7 @@ export enum PropertyName {
     DeviceMotionAutoCruise = "motionAutoCruise",  // Flooglight T8423
     DeviceMotionOutOfViewDetection = "motionOutOfViewDetection",  // Flooglight T8423
     DevicePersonDetected = "personDetected",
-    DevicePersonName = "personName",
+    DevicePeopleNames = "peopleNames",
     DeviceRTSPStream = "rtspStream",
     DeviceRTSPStreamUrl = "rtspStreamUrl",
     DeviceWatermark = "watermark",

--- a/src/push/models.ts
+++ b/src/push/models.ts
@@ -239,7 +239,7 @@ export interface PushMessage {
     short_user_id?: string;
     station_guard_mode?: number;
     station_current_mode?: number;
-    people_names?: string;
+    person_name?: string;
     sensor_open?: boolean;
     device_online?: boolean;
     fetch_id?: number;

--- a/src/push/models.ts
+++ b/src/push/models.ts
@@ -79,6 +79,11 @@ export interface BatteryDoorbellPushData {
     pic_url: string;
     push_count: number;
     notification_style: number;
+    objects?: DoorbellPeopleNames;
+}
+
+export interface DoorbellPeopleNames {
+    names: string[];
 }
 
 export interface RawPushMessage {
@@ -234,7 +239,7 @@ export interface PushMessage {
     short_user_id?: string;
     station_guard_mode?: number;
     station_current_mode?: number;
-    person_name?: string;
+    people_names?: string;
     sensor_open?: boolean;
     device_online?: boolean;
     fetch_id?: number;

--- a/src/push/service.ts
+++ b/src/push/service.ts
@@ -340,6 +340,12 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                 } catch (error) {
                     this.log.error(`Type ${DeviceType[normalized_message.type]} BatteryDoorbellPushData - push_time - Error:`, error);
                 }
+
+                //Get family face names from Doorbell Dual "Family Recognition" event
+                if (push_data.objects !== undefined) {
+                    normalized_message.people_names = push_data.objects.names !== undefined ? push_data.objects.names.join(",") : "";
+                }
+
                 normalized_message.channel = push_data.channel !== undefined ? push_data.channel : 0;
                 normalized_message.cipher = push_data.cipher !== undefined ? push_data.cipher : 0;
                 normalized_message.event_session = push_data.session_id !== undefined ? push_data.session_id : "";
@@ -441,7 +447,7 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                 normalized_message.short_user_id = push_data.short_user_id;
                 normalized_message.station_guard_mode = push_data.arming;
                 normalized_message.station_current_mode = push_data.mode;
-                normalized_message.person_name = push_data.f;
+                normalized_message.people_names = push_data.f;
                 normalized_message.sensor_open = push_data.e !== undefined ? push_data.e === "1" ? true : false : undefined;
                 normalized_message.device_online = push_data.m !== undefined ? push_data.m === 1 ? true : false : undefined;
                 try {

--- a/src/push/service.ts
+++ b/src/push/service.ts
@@ -343,7 +343,7 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
 
                 //Get family face names from Doorbell Dual "Family Recognition" event
                 if (push_data.objects !== undefined) {
-                    normalized_message.people_names = push_data.objects.names !== undefined ? push_data.objects.names.join(",") : "";
+                    normalized_message.person_name = push_data.objects.names !== undefined ? push_data.objects.names.join(",") : "";
                 }
 
                 normalized_message.channel = push_data.channel !== undefined ? push_data.channel : 0;
@@ -447,7 +447,7 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                 normalized_message.short_user_id = push_data.short_user_id;
                 normalized_message.station_guard_mode = push_data.arming;
                 normalized_message.station_current_mode = push_data.mode;
-                normalized_message.people_names = push_data.f;
+                normalized_message.person_name = push_data.f;
                 normalized_message.sensor_open = push_data.e !== undefined ? push_data.e === "1" ? true : false : undefined;
                 normalized_message.device_online = push_data.m !== undefined ? push_data.m === 1 ? true : false : undefined;
                 try {

--- a/src/push/types.ts
+++ b/src/push/types.ts
@@ -65,7 +65,8 @@ export enum DoorbellPushEvent {
     FACE_DETECTION = 3102,
     PRESS_DOORBELL = 3103,
     OFFLINE = 3106,
-    ONLINE = 3107
+    ONLINE = 3107,
+    FAMILY_DETECTION = 3303,
 }
 
 export enum LockPushEvent {


### PR DESCRIPTION
After fiddling around with familiar faces, I noticed it actually works really well if you preload the faces.
The doorbell is somehow sh*t at detecting _new_ faces, but recognizes people with a good preloaded reference picture instantly.
Turns out the names of the people are also added in the push data (see below).

Considering this eufy data is an array, I changed the existing `personName` parameter to `peopleNames`.
I also added event type `3303` which is currently unhandled but is the `family spotted` event (eg. facial recognition got a match).
I **explicitly** did not create a separate "family detected" event as that's just eufy marketing BS. In the app you can label "family" as "Family", "Friend", "Neighbor", "Courier", "Others". Calling it "family recognition" sounds less privacy intrusive than blatantly stating it can recognize faces of _anyone_ coming to your frontdoor.
That's why I just write the people names to the existing "person detected" event.

```
{
  id: 'XXXXXXXX',
  from: 'XXXXXXXXXX',
  to: 'XXXXXXXXXXXXXXXXXXXXXXX',
  category: 'com.oceanwing.battery.cam',
  persistentId: 'XXXXXXXXXXXXXXX',
  ttl: 3600,
  sent: 'XXXXXXXXXX',
  payload: {
    device_sn: 'T8213XXXXXXXXX',
    payload: {
      event_type: 3303,
      device_sn: 'T8213XXXXXXXXX',
      name: 'Frontdoor',
      channel: 0,
      cipher: 181,
      session_id: '20220709_143939',
      pic_url: '',
      create_time: 1657370379264,
      file_path: 'h265_20220709143934',
      notification_style: 3,
      push_count: 1,
      faceid: XXXXXXX,
      objects: {
        names: [
          'Test'
        ]
      }
    },
    station_sn: 'T8010XXXXXXXXX',
    'google.c.sender.id': '348804314802',
    type: '91',
    title: '',
    push_time: '1657370379784',
    content: 'Frontdoor:family has been spotted',
    event_time: '1657370379265'
  }
}
```