### PR TITLE
fix smartlock

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1923,7 +1923,6 @@ export class Lock extends Device {
                     case LockPushEvent.MULTIPLE_ERRORS:
                     {
                         const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
-                        this.updateProperty(PropertyName.DeviceLocked, false);
                         this.updateRawProperty(cmdType, "5");
                         break;
                     }

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1902,7 +1902,6 @@ export class Lock extends Device {
                     {
                         const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
                         this.updateRawProperty(cmdType, "4");
-                        this.updateProperty(PropertyName.DeviceLocked, true);
                         this.emit("locked", this, this.getPropertyValue(PropertyName.DeviceLocked) as boolean);
                         break;
                     }

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1869,24 +1869,6 @@ export class Lock extends Device {
         return Buffer.concat([buf1, buf2, buf3, buf4]);
     }
 
-    protected convertRawPropertyValue(property: PropertyMetadataAny, value: string): PropertyValue {
-        try {
-            if (property.key === CommandType.CMD_DOORLOCK_GET_STATE || property.key === CommandType.CMD_SMARTLOCK_QUERY_STATUS) {
-                switch (value) {
-                    case "3":
-                        return 3;
-                    case "4":
-                        return 4;
-                    case "5":
-                        return 5;
-                }
-            }
-        } catch (error) {
-            this.log.error("Convert Error:", { property: property, value: value, error: error });
-        }
-        return super.convertRawPropertyValue(property, value);
-    }
-
     public processPushNotification(message: PushMessage, eventDurationSeconds: number): void {
         super.processPushNotification(message, eventDurationSeconds);
         if (message.event_type !== undefined) {

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1914,7 +1914,6 @@ export class Lock extends Device {
                     {
                         const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
                         this.updateRawProperty(cmdType, "3");
-                        this.updateProperty(PropertyName.DeviceLocked, false);
                         this.emit("locked", this, this.getPropertyValue(PropertyName.DeviceLocked) as boolean);
                         break;
                     }

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1871,12 +1871,14 @@ export class Lock extends Device {
 
     protected convertRawPropertyValue(property: PropertyMetadataAny, value: string): PropertyValue {
         try {
-            if (property.key === CommandType.CMD_DOORLOCK_GET_STATE) {
+            if (property.key === CommandType.CMD_DOORLOCK_GET_STATE || property.key === CommandType.CMD_SMARTLOCK_QUERY_STATUS) {
                 switch (value) {
                     case "3":
-                        return false;
+                        return 3;
                     case "4":
-                        return true;
+                        return 4;
+                    case "5":
+                        return 5;
                 }
             }
         } catch (error) {
@@ -1918,6 +1920,7 @@ export class Lock extends Device {
                     {
                         const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
                         this.updateRawProperty(cmdType, "4");
+                        this.updateProperty(PropertyName.DeviceLocked, true);
                         this.emit("locked", this, this.getPropertyValue(PropertyName.DeviceLocked) as boolean);
                         break;
                     }
@@ -1930,6 +1933,7 @@ export class Lock extends Device {
                     {
                         const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
                         this.updateRawProperty(cmdType, "3");
+                        this.updateProperty(PropertyName.DeviceLocked, false);
                         this.emit("locked", this, this.getPropertyValue(PropertyName.DeviceLocked) as boolean);
                         break;
                     }
@@ -1939,6 +1943,7 @@ export class Lock extends Device {
                     case LockPushEvent.MULTIPLE_ERRORS:
                     {
                         const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
+                        this.updateProperty(PropertyName.DeviceLocked, false);
                         this.updateRawProperty(cmdType, "5");
                         break;
                     }


### PR DESCRIPTION
In the current version the raw `DeviceLockState` property was not converted properly (would be `true/false` instead of `3, 4, 5`. This leads to the Lock always reported as Unlocked [here](https://github.com/bropat/eufy-security-client/blob/54f94083592feeeaf8e53ab77b521f4cd62aea04/src/http/device.ts#L1841).

Also if the lock is manually locked/unlocked the `DeviceLocked` property was not updated correctly.