### PR TITLE
OPT: independent DeviceChimeHomebaseRingtoneType  

### DIFF
--- a/src/eufysecurity.ts
+++ b/src/eufysecurity.ts
@@ -1087,7 +1087,7 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
                 await station.setHomebaseChimeRingtoneVolume(device, value as number);
                 break;
             case PropertyName.DeviceChimeHomebaseRingtoneType:
-                await station.setHomebaseChimeRingtoneType(device, value as number);
+                await station.setHomebaseChimeRingtoneType(value as number);
                 break;
             case PropertyName.DeviceNotificationType:
                 await station.setNotificationType(device, value as NotificationType);

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -1840,22 +1840,16 @@ export class Station extends TypedEmitter<StationEvents> {
         }
     }
 
-    public async setHomebaseChimeRingtoneType(device: Device, value: number): Promise<void> {
+    public async setHomebaseChimeRingtoneType(value: number): Promise<void> {
         const propertyData: PropertyData = {
             name: PropertyName.DeviceChimeHomebaseRingtoneType,
             value: value
         };
-        if (device.getStationSerial() !== this.getSerial()) {
-            throw new WrongStationError(`Device ${device.getSerial()} is not managed by this station ${this.getSerial()}`);
+        if (!this.hasProperty(propertyData.name)) {
+            throw new NotSupportedError(`This functionality is not implemented or supported by ${this.getSerial()}`);
         }
-        if (!device.hasProperty(propertyData.name)) {
-            throw new NotSupportedError(`This functionality is not implemented or supported by ${device.getSerial()}`);
-        }
-        const property = device.getPropertyMetadata(propertyData.name);
-        validValue(property, value);
-
-        this.log.debug(`Sending homebase chime ringtone type command to station ${this.getSerial()} for device ${device.getSerial()} with value: ${value}`);
-        if (device.isBatteryDoorbell()) {
+        this.log.debug(`Sending homebase chime ringtone type command to station ${this.getSerial()} with value: ${value}`);
+        if (this.isStation()) {
             await this.p2pSession.sendCommandWithStringPayload({
                 commandType: CommandType.CMD_SET_PAYLOAD,
                 value: JSON.stringify({
@@ -1866,12 +1860,12 @@ export class Station extends TypedEmitter<StationEvents> {
                         "dingdong_ringtone": value,
                     }
                 }),
-                channel: device.getChannel()
+                channel: 0
             }, {
                 property: propertyData
             });
         } else {
-            throw new NotSupportedError(`This functionality is not implemented or supported by ${device.getSerial()}`);
+            throw new NotSupportedError(`This functionality is not implemented or supported by ${this.getSerial()}`);
         }
     }
 

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -4896,6 +4896,7 @@ export const StationProperties: Properties = {
         [PropertyName.StationCustom2SecuritySettings]: StationCustom2SecuritySettings,
         [PropertyName.StationCustom3SecuritySettings]: StationCustom3SecuritySettings,
         [PropertyName.StationOffSecuritySettings]: StationOffSecuritySettings,
+        [PropertyName.DeviceChimeHomebaseRingtoneType]: DeviceChimeHomebaseRingtoneTypeBatteryDoorbellProperty
     },
     [DeviceType.INDOOR_CAMERA]: {
         ...BaseStationProperties,


### PR DESCRIPTION
This allows to trigger the ringtones on different Homebase. So when a users has a spare Homebase they can set it up as a additional chime device. 

No need to connect it to the doorbell