### PR TITLE
FIX: rawDevice params missing for Homebase 1

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -55,7 +55,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
                 this.updateProperty(property.name, property.default);
             }
         }
-        if (!cloudOnlyProperties) {
+        if (!cloudOnlyProperties && this.rawDevice.params) {
             this.rawDevice.params.forEach(param => {
                 this.updateRawProperty(param.param_type, param.param_value);
             });

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -131,7 +131,7 @@ export class Station extends TypedEmitter<StationEvents> {
                 this.updateProperty(property.name, property.default);
             }
         }
-        if (!cloudOnlyProperties) {
+        if (!cloudOnlyProperties && this.rawStation.params) {
             this.rawStation.params.forEach(param => {
                 this.updateRawProperty(param.param_type, param.param_value);
             });


### PR DESCRIPTION
Sometimes a Homebase 1 is missing rawDevice.params and causing a crash