### PR TITLE
Increase LOOKUP_RETRY_TIMEOUT - believed to resolve #278

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -27,7 +27,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
     private readonly MAX_COMMAND_RESULT_WAIT = 30 * 1000;
     private readonly MAX_AKNOWLEDGE_TIMEOUT = 15 * 1000;
     private readonly MAX_LOOKUP_TIMEOUT = 15 * 1000;
-    private readonly LOOKUP_RETRY_TIMEOUT = 150;
+    private readonly LOOKUP_RETRY_TIMEOUT = 15 * 1000;
     private readonly MAX_EXPECTED_SEQNO_WAIT = 20 * 1000;
     private readonly HEARTBEAT_INTERVAL = 5 * 1000;
     private readonly MAX_COMMAND_QUEUE_TIMEOUT = 120 * 1000;


### PR DESCRIPTION
changes `LOOKUP_RETRY_TIMEOUT` from `150` to `15 * 1000` which is consistent with other timeouts. I believe too short of a timeout is the root cause of #278 and successfully resolves #278 for myself without any apparent negatives.