### PR TITLE
fix problem when the P2PDID number is starting with zeros

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -732,7 +732,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                 this._clearLookupTimeout();
                 this._clearLookupRetryTimeout();
 
-                const p2pDid = `${msg.slice(4, 12).toString("utf8").replace(/[\0]+$/g, "")}-${msg.slice(12, 16).readUInt32BE()}-${msg.slice(16, 24).toString("utf8").replace(/[\0]+$/g, "")}`;
+                const p2pDid = `${msg.slice(4, 12).toString("utf8").replace(/[\0]+$/g, "")}-${msg.slice(12, 16).readUInt32BE().toString().padStart(6, '0')}-${msg.slice(16, 24).toString("utf8").replace(/[\0]+$/g, "")}`;
                 this.log.debug(`Station ${this.rawStation.station_sn} - LOCAL_LOOKUP_RESP - Got response`, { ip: rinfo.address, port: rinfo.port, p2pDid: p2pDid });
 
                 if (p2pDid === this.rawStation.p2p_did) {


### PR DESCRIPTION
With the new implementation of the local p2p lockup, a P2P DID like `XXXXXXX-030810-YYYYY` will not be recognized as the wanted station, because the P2P DID in the LOCAL_LOOKUP_RESP message will be converted to `XXXXXXX-30810-YYYYY`. This is done by `msg.slice(12, 16).readUInt32BE()` because it returns a int value witch has no leading zeros. A possible workaround would be to add `.toString().padStart(6, '0')`, in the case that the number has always 6 digits.

If there could be another amount of digits in the P2P DID, we may must use a temporarily changed value for `this.rawStation.p2p_did`.