### PR TITLE
FIX: HB3 connected sensors not reporting

### DIFF
--- a/src/push/service.ts
+++ b/src/push/service.ts
@@ -343,7 +343,7 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                 this.log.error(`Type ${DeviceType[normalized_message.type]} CusPush - push_time - Error:`, error);
             }
 
-            if (normalized_message.station_sn.startsWith("T8030") || normalized_message.type === DeviceType.HB3) {
+            if (normalized_message.type === DeviceType.HB3) {
                 const push_data = message.payload.payload as PlatformPushMode;
                 normalized_message.name = push_data.name ? push_data.name : "";
                 normalized_message.channel = push_data.channel !== undefined ? push_data.channel : 0;


### PR DESCRIPTION
The check for HB3 is preventing the integration to set the door Sensor Custom Push data 

In the logging of my Homey integration i see:

```
{
  name: '',
  event_time: -9205462985303130000,
  type: 2,
  station_sn: 'T8030REDACTED',
  device_sn: 'T8900REDACTED',
  title: 'Eufy Security',
  content: 'Keukenraam is open',
  push_time: 1681109148578,
  channel: 0,
  cipher: 0,
  event_session: '',
  event_type: 3,
  file_path: '',
  pic_url: '',
  push_count: 1,
  notification_style: undefined,
  storage_type: 1,
  msg_type: undefined,
  person_name: undefined,
  person_id: undefined,
  tfcard_status: undefined,
  user_type: undefined,
  user_name: undefined,
  station_guard_mode: undefined,
  station_current_mode: undefined,
  alarm_delay: undefined,
  sound_alarm: undefined
}
```