### PR TITLE
Add support of notification and station commands for Starlight 4G LTE

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -729,7 +729,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
             type == DeviceType.INDOOR_COST_DOWN_CAMERA ||
             type == DeviceType.FLOODLIGHT_CAMERA_8422 ||
             type == DeviceType.FLOODLIGHT_CAMERA_8423 ||
-            type == DeviceType.FLOODLIGHT_CAMERA_8424)
+            type == DeviceType.FLOODLIGHT_CAMERA_8424 ||
+            type == DeviceType.CAMERA_FG)
             return true;
         return false;
     }
@@ -852,12 +853,12 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     static isLock(type: number): boolean {
         return Device.isLockBle(type) ||
-        Device.isLockWifi(type) ||
-        Device.isLockBleNoFinger(type) ||
-        Device.isLockWifiNoFinger(type) ||
-        Device.isLockWifiR10(type) ||
-        Device.isLockWifiR20(type) ||
-        Device.isLockWifiVideo(type);
+            Device.isLockWifi(type) ||
+            Device.isLockBleNoFinger(type) ||
+            Device.isLockWifiNoFinger(type) ||
+            Device.isLockWifiR10(type) ||
+            Device.isLockWifiR20(type) ||
+            Device.isLockWifiVideo(type);
     }
 
     static isLockKeypad(type: number): boolean {
@@ -2408,31 +2409,31 @@ export class Lock extends Device {
                     case LockPushEvent.MANUAL_LOCK:
                     case LockPushEvent.PW_LOCK:
                     case LockPushEvent.TEMPORARY_PW_LOCK:
-                    {
-                        const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
-                        this.updateRawProperty(cmdType, "4");
-                        break;
-                    }
+                        {
+                            const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
+                            this.updateRawProperty(cmdType, "4");
+                            break;
+                        }
                     case LockPushEvent.APP_UNLOCK:
                     case LockPushEvent.AUTO_UNLOCK:
                     case LockPushEvent.FINGERPRINT_UNLOCK:
                     case LockPushEvent.MANUAL_UNLOCK:
                     case LockPushEvent.PW_UNLOCK:
                     case LockPushEvent.TEMPORARY_PW_UNLOCK:
-                    {
-                        const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
-                        this.updateRawProperty(cmdType, "3");
-                        break;
-                    }
+                        {
+                            const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
+                            this.updateRawProperty(cmdType, "3");
+                            break;
+                        }
                     case LockPushEvent.LOCK_MECHANICAL_ANOMALY:
                     case LockPushEvent.MECHANICAL_ANOMALY:
                     case LockPushEvent.VIOLENT_DESTRUCTION:
                     case LockPushEvent.MULTIPLE_ERRORS:
-                    {
-                        const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
-                        this.updateRawProperty(cmdType, "5");
-                        break;
-                    }
+                        {
+                            const cmdType = this.isLockBle() || this.isLockBleNoFinger() ? CommandType.CMD_DOORLOCK_GET_STATE : CommandType.CMD_SMARTLOCK_QUERY_STATUS;
+                            this.updateRawProperty(cmdType, "5");
+                            break;
+                        }
                     case LockPushEvent.LOW_POWER:
                     case LockPushEvent.VERY_LOW_POWER:
                         this.updateProperty(PropertyName.DeviceLowBatteryAlert, true);
@@ -2868,15 +2869,15 @@ export class SmartSafe extends Device {
             if (property.key === CommandType.CMD_SMARTSAFE_REMOTE_OPEN_TYPE) {
                 switch (property.name) {
                     case PropertyName.DeviceRemoteUnlock:
-                    {
-                        const booleanProperty = property as PropertyMetadataBoolean;
-                        return value !== undefined ? (value === "0" || value === "1" ? true : false) : booleanProperty.default !== undefined ? booleanProperty.default : false;
-                    }
+                        {
+                            const booleanProperty = property as PropertyMetadataBoolean;
+                            return value !== undefined ? (value === "0" || value === "1" ? true : false) : booleanProperty.default !== undefined ? booleanProperty.default : false;
+                        }
                     case PropertyName.DeviceRemoteUnlockMasterPIN:
-                    {
-                        const booleanProperty = property as PropertyMetadataBoolean;
-                        return value !== undefined ? (value === "0" ? true : false) : booleanProperty.default !== undefined ? booleanProperty.default : false;
-                    }
+                        {
+                            const booleanProperty = property as PropertyMetadataBoolean;
+                            return value !== undefined ? (value === "0" ? true : false) : booleanProperty.default !== undefined ? booleanProperty.default : false;
+                        }
                 }
             } else if (property.key === CommandType.CMD_SMARTSAFE_NOTIF) {
                 const booleanProperty = property as PropertyMetadataBoolean;
@@ -2943,63 +2944,63 @@ export class SmartSafe extends Device {
                     switch (message.event_type) {
                         //TODO: Finish smart safe push notification handling implementation
                         case SmartSafeEvent.LOCK_STATUS:
-                        {
-                            const eventValues = message.event_value as SmartSafeEventValueDetail;
+                            {
+                                const eventValues = message.event_value as SmartSafeEventValueDetail;
 
-                            if (eventValues.action === 0) {
-                                this.updateRawProperty(CommandType.CMD_SMARTSAFE_LOCK_STATUS, "0");
-                                /*
-                                    type values:
-                                        1: Unlocked by PIN
-                                        2: Unlocked by User
-                                        3: Unlocked by key
-                                        4: Unlocked by App
-                                        5: Unlocked by Dual Unlock
-                                */
-                            } else if (eventValues.action === 1) {
-                                this.updateRawProperty(CommandType.CMD_SMARTSAFE_LOCK_STATUS, "1");
-                            } else if (eventValues.action === 2) {
-                                this.jammedEvent(eventDurationSeconds);
-                            } else if (eventValues.action === 3) {
-                                this.lowBatteryEvent(eventDurationSeconds);
+                                if (eventValues.action === 0) {
+                                    this.updateRawProperty(CommandType.CMD_SMARTSAFE_LOCK_STATUS, "0");
+                                    /*
+                                        type values:
+                                            1: Unlocked by PIN
+                                            2: Unlocked by User
+                                            3: Unlocked by key
+                                            4: Unlocked by App
+                                            5: Unlocked by Dual Unlock
+                                    */
+                                } else if (eventValues.action === 1) {
+                                    this.updateRawProperty(CommandType.CMD_SMARTSAFE_LOCK_STATUS, "1");
+                                } else if (eventValues.action === 2) {
+                                    this.jammedEvent(eventDurationSeconds);
+                                } else if (eventValues.action === 3) {
+                                    this.lowBatteryEvent(eventDurationSeconds);
+                                }
+                                break;
                             }
-                            break;
-                        }
                         case SmartSafeEvent.ALARM_911:
-                        {
-                            const eventValue = message.event_value as number;
-                            this.alarm911Event(eventValue, eventDurationSeconds);
-                            break;
-                        }
-                        case SmartSafeEvent.SHAKE_ALARM:
-                        {
-                            const eventValue = message.event_value as number;
-                            this.shakeEvent(eventValue, eventDurationSeconds);
-                            break;
-                        }
-                        case SmartSafeEvent.LONG_TIME_NOT_CLOSE:
-                        {
-                            const eventValue = message.event_value as number;
-                            if (eventValue === 1) {
-                                this.updateProperty(PropertyName.DeviceLongTimeNotCloseAlert, true);
-                                this.clearEventTimeout(DeviceEvent.LongTimeNotClose);
-                                this.eventTimeouts.set(DeviceEvent.LongTimeNotClose, setTimeout(async () => {
-                                    this.updateProperty(PropertyName.DeviceLongTimeNotCloseAlert, false);
-                                    this.eventTimeouts.delete(DeviceEvent.LongTimeNotClose);
-                                }, eventDurationSeconds * 1000));
+                            {
+                                const eventValue = message.event_value as number;
+                                this.alarm911Event(eventValue, eventDurationSeconds);
+                                break;
                             }
-                            break;
-                        }
+                        case SmartSafeEvent.SHAKE_ALARM:
+                            {
+                                const eventValue = message.event_value as number;
+                                this.shakeEvent(eventValue, eventDurationSeconds);
+                                break;
+                            }
+                        case SmartSafeEvent.LONG_TIME_NOT_CLOSE:
+                            {
+                                const eventValue = message.event_value as number;
+                                if (eventValue === 1) {
+                                    this.updateProperty(PropertyName.DeviceLongTimeNotCloseAlert, true);
+                                    this.clearEventTimeout(DeviceEvent.LongTimeNotClose);
+                                    this.eventTimeouts.set(DeviceEvent.LongTimeNotClose, setTimeout(async () => {
+                                        this.updateProperty(PropertyName.DeviceLongTimeNotCloseAlert, false);
+                                        this.eventTimeouts.delete(DeviceEvent.LongTimeNotClose);
+                                    }, eventDurationSeconds * 1000));
+                                }
+                                break;
+                            }
                         case SmartSafeEvent.LOW_POWER:
-                        {
-                            this.lowBatteryEvent(eventDurationSeconds);
-                            break;
-                        }
+                            {
+                                this.lowBatteryEvent(eventDurationSeconds);
+                                break;
+                            }
                         case SmartSafeEvent.INPUT_ERR_MAX:
-                        {
-                            this.wrongTryProtectAlarmEvent(eventDurationSeconds);
-                            break;
-                        }
+                            {
+                                this.wrongTryProtectAlarmEvent(eventDurationSeconds);
+                                break;
+                            }
                         default:
                             this.log.debug("Unhandled smart safe notification event", message.event_type, message.event_time, message.device_sn);
                             break;

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -506,8 +506,12 @@ export class Station extends TypedEmitter<StationEvents> {
                 }
             } else if (message.event_type === CusPushEvent.ALARM && message.station_sn === this.getSerial() && !this.isStation()) {
                 this.log.info("Received push notification for alarm event", { stationSN: message.station_sn, alarmType: message.alarm_type });
-                if (message.alarm_type !== undefined)
+                if (message.alarm_type !== undefined) {
                     this.emit("alarm event", this, message.alarm_type);
+                    if (message.type == DeviceType.CAMERA_FG) {
+                        this.onAlarmEvent(message.alarm_type)
+                    }
+                }
             }
         } else if (message.msg_type === CusPushEvent.TFCARD && message.station_sn === this.getSerial() && message.tfcard_status !== undefined) {
             this.updateRawProperty(CommandType.CMD_GET_TFCARD_STATUS, message.tfcard_status.toString());

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -767,6 +767,7 @@ export const GenericTypeProperty: PropertyMetadataNumeric = {
         90: "SmartDrop, Smart Delivery Box",
         91: "Video Doorbell Dual",
         93: "Video Doorbell Dual (Wired)",
+        110: "Starlight 4G LTE"
     },
 }
 

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -432,7 +432,7 @@ export enum PropertyName {
     DeviceWifiRSSI = "wifiRssi",
     DeviceWifiSignalLevel = "wifiSignalLevel",
     DeviceEnabled = "enabled",
-    DeviceAntitheftDetection= "antitheftDetection",
+    DeviceAntitheftDetection = "antitheftDetection",
     DeviceAutoNightvision = "autoNightvision",
     DeviceNightvision = "nightvision",
     DeviceStatusLed = "statusLed",
@@ -1052,7 +1052,7 @@ export const DeviceStatusLedDoorbellProperty: PropertyMetadataBoolean = {
 
 export const DeviceStatusLedT8200XProperty: PropertyMetadataBoolean = {
     ...DeviceStatusLedProperty,
-    key:ParamType.COMMAND_LED_NIGHT_OPEN,
+    key: ParamType.COMMAND_LED_NIGHT_OPEN,
     commandId: ParamType.COMMAND_LED_NIGHT_OPEN,
 };
 
@@ -6616,6 +6616,16 @@ export const StationCommands: Commands = {
     [DeviceType.FLOODLIGHT_CAMERA_8424]: [
         CommandName.StationReboot,
         CommandName.StationTriggerAlarmSound,
+        CommandName.StationDownloadImage,
+        CommandName.StationDatabaseQueryLatestInfo,
+        CommandName.StationDatabaseQueryLocal,
+        CommandName.StationDatabaseCountByDate,
+        CommandName.StationDatabaseDelete,
+    ],
+    [DeviceType.CAMERA_FG]: [
+        CommandName.StationReboot,
+        CommandName.StationTriggerAlarmSound,
+        CommandName.StationChime,
         CommandName.StationDownloadImage,
         CommandName.StationDatabaseQueryLatestInfo,
         CommandName.StationDatabaseQueryLocal,

--- a/src/push/models.ts
+++ b/src/push/models.ts
@@ -44,6 +44,7 @@ export interface CusPushData {
     user_id?: string;
     user_name?: string;                 // Username
     bat_low?: string;
+    msg_type: number;
 }
 
 export interface EufyPushMessage {
@@ -201,28 +202,6 @@ export interface DoorbellPushData {
 }
 
 export interface IndoorPushData {
-    a: number;
-    channel: number;
-    cipher: number;
-    create_time: number;
-    trigger_time: number;
-    device_sn: string;
-    event_type: number;
-    file_path: string;
-    msg_type: number;
-    name: string;
-    notification_style: number;
-    pic_url: string;
-    push_count: number;
-    session_id: string;
-    storage_type: number;
-    t: number;
-    tfcard_status: number;
-    timeout: number;
-    unique_id: string;
-}
-
-export interface Starlight4GLTEPushData {
     a: number;
     channel: number;
     cipher: number;

--- a/src/push/models.ts
+++ b/src/push/models.ts
@@ -222,6 +222,28 @@ export interface IndoorPushData {
     unique_id: string;
 }
 
+export interface Starlight4GLTEPushData {
+    a: number;
+    channel: number;
+    cipher: number;
+    create_time: number;
+    trigger_time: number;
+    device_sn: string;
+    event_type: number;
+    file_path: string;
+    msg_type: number;
+    name: string;
+    notification_style: number;
+    pic_url: string;
+    push_count: number;
+    session_id: string;
+    storage_type: number;
+    t: number;
+    tfcard_status: number;
+    timeout: number;
+    unique_id: string;
+}
+
 export interface ServerPushData {
     email: string;
     nick_name: string;

--- a/src/push/service.ts
+++ b/src/push/service.ts
@@ -4,7 +4,7 @@ import { dummyLogger, Logger } from "ts-log";
 import { TypedEmitter } from "tiny-typed-emitter";
 
 import { buildCheckinRequest, convertTimestampMs, generateFid, parseCheckinResponse, sleep } from "./utils";
-import { CheckinResponse, Credentials, CusPushData, DoorbellPushData, FidInstallationResponse, FidTokenResponse, GcmRegisterResponse, IndoorPushData, RawPushMessage, PushMessage, BatteryDoorbellPushData, LockPushData, SmartSafeData, PlatformPushMode, Starlight4GLTEPushData } from "./models";
+import { CheckinResponse, Credentials, CusPushData, DoorbellPushData, FidInstallationResponse, FidTokenResponse, GcmRegisterResponse, IndoorPushData, RawPushMessage, PushMessage, BatteryDoorbellPushData, LockPushData, SmartSafeData, PlatformPushMode } from "./models";
 import { PushClient } from "./client";
 import { PushNotificationServiceEvents } from "./interfaces";
 import { Device } from "../http/device";
@@ -384,23 +384,6 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                     normalized_message.pic_url = push_data.pic_url !== undefined ? push_data.pic_url : "";
                     normalized_message.push_count = push_data.push_count !== undefined ? push_data.push_count : 1;
                     normalized_message.notification_style = push_data.notification_style;
-                } else if (Device.isStarlight4GLTE(normalized_message.type)) {
-                    const push_data = message.payload.payload as Starlight4GLTEPushData;
-                    normalized_message.name = push_data.name ? push_data.name : "";
-                    normalized_message.channel = push_data.channel;
-                    normalized_message.cipher = push_data.cipher;
-                    normalized_message.event_session = push_data.session_id;
-                    normalized_message.event_type = push_data.event_type;
-                    //normalized_message.file_path = push_data.file_path !== undefined && push_data.file_path !== "" && push_data.channel !== undefined ? getAbsoluteFilePath(normalized_message.type, push_data.channel, push_data.file_path) : "";
-                    normalized_message.file_path = push_data.file_path;
-                    normalized_message.pic_url = push_data.pic_url !== undefined ? push_data.pic_url : "";
-                    normalized_message.push_count = push_data.push_count !== undefined ? push_data.push_count : 1;
-                    normalized_message.notification_style = push_data.notification_style;
-                    normalized_message.msg_type = push_data.msg_type;
-                    normalized_message.timeout = push_data.timeout;
-                    normalized_message.tfcard_status = push_data.tfcard_status;
-                    normalized_message.storage_type = push_data.storage_type !== undefined ? push_data.storage_type : 1;
-                    normalized_message.unique_id = push_data.unique_id;
                 } else if (Device.isIndoorCamera(normalized_message.type) ||
                     Device.isSoloCameras(normalized_message.type) ||
                     Device.isFloodLightT8420X(normalized_message.type, normalized_message.device_sn) ||
@@ -485,6 +468,15 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                     normalized_message.automation_id = push_data.automation_id;
                     normalized_message.click_action = push_data.click_action;
                     normalized_message.news_id = push_data.news_id;
+
+                    if (Device.isStarlight4GLTE(normalized_message.type)) {
+                        normalized_message.name = push_data.name ? push_data.name : "";
+                        normalized_message.channel = push_data.channel;
+                        normalized_message.cipher = push_data.cipher;
+                        normalized_message.event_type = push_data.event_type;
+                        normalized_message.file_path = push_data.file_path;
+                        normalized_message.msg_type = push_data.msg_type;
+                    }
                 }
             }
         } else if (message.payload.doorbell !== undefined) {

--- a/src/push/service.ts
+++ b/src/push/service.ts
@@ -4,7 +4,7 @@ import { dummyLogger, Logger } from "ts-log";
 import { TypedEmitter } from "tiny-typed-emitter";
 
 import { buildCheckinRequest, convertTimestampMs, generateFid, parseCheckinResponse, sleep } from "./utils";
-import { CheckinResponse, Credentials, CusPushData, DoorbellPushData, FidInstallationResponse, FidTokenResponse, GcmRegisterResponse, IndoorPushData, RawPushMessage, PushMessage, BatteryDoorbellPushData, LockPushData, SmartSafeData, PlatformPushMode } from "./models";
+import { CheckinResponse, Credentials, CusPushData, DoorbellPushData, FidInstallationResponse, FidTokenResponse, GcmRegisterResponse, IndoorPushData, RawPushMessage, PushMessage, BatteryDoorbellPushData, LockPushData, SmartSafeData, PlatformPushMode, Starlight4GLTEPushData } from "./models";
 import { PushClient } from "./client";
 import { PushNotificationServiceEvents } from "./interfaces";
 import { Device } from "../http/device";
@@ -384,6 +384,23 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                     normalized_message.pic_url = push_data.pic_url !== undefined ? push_data.pic_url : "";
                     normalized_message.push_count = push_data.push_count !== undefined ? push_data.push_count : 1;
                     normalized_message.notification_style = push_data.notification_style;
+                } else if (Device.isStarlight4GLTE(normalized_message.type)) {
+                    const push_data = message.payload.payload as Starlight4GLTEPushData;
+                    normalized_message.name = push_data.name ? push_data.name : "";
+                    normalized_message.channel = push_data.channel;
+                    normalized_message.cipher = push_data.cipher;
+                    normalized_message.event_session = push_data.session_id;
+                    normalized_message.event_type = push_data.event_type;
+                    //normalized_message.file_path = push_data.file_path !== undefined && push_data.file_path !== "" && push_data.channel !== undefined ? getAbsoluteFilePath(normalized_message.type, push_data.channel, push_data.file_path) : "";
+                    normalized_message.file_path = push_data.file_path;
+                    normalized_message.pic_url = push_data.pic_url !== undefined ? push_data.pic_url : "";
+                    normalized_message.push_count = push_data.push_count !== undefined ? push_data.push_count : 1;
+                    normalized_message.notification_style = push_data.notification_style;
+                    normalized_message.msg_type = push_data.msg_type;
+                    normalized_message.timeout = push_data.timeout;
+                    normalized_message.tfcard_status = push_data.tfcard_status;
+                    normalized_message.storage_type = push_data.storage_type !== undefined ? push_data.storage_type : 1;
+                    normalized_message.unique_id = push_data.unique_id;
                 } else if (Device.isIndoorCamera(normalized_message.type) ||
                     Device.isSoloCameras(normalized_message.type) ||
                     Device.isFloodLightT8420X(normalized_message.type, normalized_message.device_sn) ||

--- a/src/push/service.ts
+++ b/src/push/service.ts
@@ -470,11 +470,21 @@ export class PushNotificationService extends TypedEmitter<PushNotificationServic
                     normalized_message.news_id = push_data.news_id;
 
                     if (Device.isStarlight4GLTE(normalized_message.type)) {
-                        normalized_message.name = push_data.name ? push_data.name : "";
-                        normalized_message.channel = push_data.channel;
-                        normalized_message.cipher = push_data.cipher;
-                        normalized_message.event_type = push_data.event_type;
-                        normalized_message.file_path = push_data.file_path;
+                        if (push_data.name && push_data.name !== null && push_data.name !== "") {
+                            normalized_message.name = push_data.name
+                        }
+                        if (push_data.channel && push_data.channel !== null && push_data.channel !== undefined) {
+                            normalized_message.channel = push_data.channel
+                        }
+                        if (push_data.cipher && push_data.cipher !== null && push_data.cipher !== undefined) {
+                            normalized_message.cipher = push_data.cipher
+                        }
+                        if (push_data.event_type && push_data.event_type !== null && push_data.event_type !== undefined) {
+                            normalized_message.event_type = push_data.event_type
+                        }
+                        if (push_data.file_path && push_data.file_path !== null && push_data.file_path !== undefined) {
+                            normalized_message.file_path = push_data.file_path
+                        }
                         normalized_message.msg_type = push_data.msg_type;
                     }
                 }


### PR DESCRIPTION
This PR solving issue with not working some events for Starlight 4G LTE camera. I checked logs for this camera and I found that part of events use different payload structure - that was a root problem why some events was not supported. Also I found that `station` was correctly discovered plugin, but `camera` devices not (plugin always showed me unsupported device). Also that was a reason why some of events was not correctly supported.

Also in the new version on `eufy-security-client` I saw problem with not supported some command for `station`. I realised that Starlight 4G LTE not contains necessary "commands". This update fixing this issue, and now I can run docker container with with lates version 2.6.2 library version. 