### PR TITLE
check the length of response for CMD_SD_INFO_EX

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1307,7 +1307,12 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                             } else if (msg_state.commandType === CommandType.CMD_STOP_TALKBACK || (msg_state.commandType === CommandType.CMD_DOORBELL_SET_PAYLOAD && msg_state.nestedCommandType === IndoorSoloSmartdropCommandType.CMD_END_SPEAK)) {
                                 this.stopTalkback(msg_state.channel);
                             } else if (msg_state.commandType === CommandType.CMD_SDINFO_EX){
-                                this.emit("sd info ex", message.data.slice(0, 4).readUInt32LE(), message.data.slice(4, 8).readUInt32LE(), message.data.slice(8, 12).readUInt32LE());
+                                if(message.data.length == 12){
+                                    this.emit("sd info ex", message.data.slice(0, 4).readUInt32LE(), message.data.slice(4, 8).readUInt32LE(), message.data.slice(8, 12).readUInt32LE());
+                                } else {
+                                    this.log.debug(`Handle DATA CMD_SDINFO_EX - Unsupported data length`, { stationSN: this.rawStation.station_sn, message: { seqNo: message.seqNo, commandType: message.commandId, channel: message.channel, signCode: message.signCode, data: message.data.toString("hex") } });
+                                    this.emit("sd info ex", -1, -1, -1);
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
Since HomeBase 2 is updated to v3.3.0.1h (also valid for v3.3.0.4h), the HomeBase 2 answering the `CMD_SD_INFO_EX` command with a 132 byte long "`0`" response. HomeBase 3 (v3.3.0.3) will send a correct response.

So I added checking the length of the response, it will be parsed if length is 12, otherwise `sdStatus`, `sdCapacity` and `sdCapacityAvailable` will be populated with `-1`.