### PR TITLE
Storage info s100

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -7061,6 +7061,9 @@ export const StationProperties: Properties = {
         [PropertyName.StationAlarm]: StationAlarmProperty,
         [PropertyName.StationAlarmType]: StationAlarmTypeProperty,
         [PropertyName.StationAlarmVolume]: StationAlarmVolumeWalllightProperty,
+        [PropertyName.StationSdStatus]: StationSdStatusProperty,
+        [PropertyName.StationSdCapacity]: StationSdCapacityProperty,
+        [PropertyName.StationSdCapacityAvailable]: StationSdAvailableCapacityProperty,
     },
     [DeviceType.CAMERA_GARAGE_T8452]: {
         ...BaseStationProperties,


### PR DESCRIPTION
I was able to verify that the S100 wall light cam also supports storage info.