### PR TITLE
OPT: persistentData via config instead of JSON file

### DIFF
--- a/src/eufysecurity.ts
+++ b/src/eufysecurity.ts
@@ -123,7 +123,7 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
         }
 
         try {
-            if (fse.statSync(this.persistentFile).isFile()) {
+            if (!this.config.persistentData && fse.statSync(this.persistentFile).isFile()) {
                 const fileContent = fse.readFileSync(this.persistentFile, "utf8");
                 this.persistentData = JSON.parse(fileContent) as EufySecurityPersistentData;
             }

--- a/src/eufysecurity.ts
+++ b/src/eufysecurity.ts
@@ -115,7 +115,12 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
         } else if (!fse.existsSync(this.config.persistentDir)) {
             this.config.persistentDir = path.resolve(__dirname, "../../..");
         }
-        this.persistentFile = path.join(this.config.persistentDir, "persistent.json");
+
+        if (this.config.persistentData) {
+            this.persistentData = JSON.parse(this.config.persistentData) as EufySecurityPersistentData;
+        } else {
+            this.persistentFile = path.join(this.config.persistentDir, "persistent.json");
+        }
 
         try {
             if (fse.statSync(this.persistentFile).isFile()) {
@@ -862,7 +867,11 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
         this.persistentData.httpApi = this.api?.getPersistentData();
         this.persistentData.country = this.api?.getCountry();
         try {
-            fse.writeFileSync(this.persistentFile, JSON.stringify(this.persistentData));
+            if(this.config.persistentData) {
+                this.emit("persistent data", JSON.stringify(this.persistentData));
+            } else {
+                fse.writeFileSync(this.persistentFile, JSON.stringify(this.persistentData));
+            }
         } catch (err) {
             const error = ensureError(err);
             this.log.error("WritePersistentData Error", { error: getError(error) });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,7 @@ export interface EufySecurityConfig {
     language?: string;
     trustedDeviceName?: string;
     persistentDir?: string;
+    persistentData?: string;
     p2pConnectionSetup: number;
     pollingIntervalMinutes: number;
     eventDurationSeconds: number;
@@ -109,6 +110,7 @@ export interface EufySecurityEvents {
     "connection error": (error: Error) => void;
     "tfa request": () => void;
     "captcha request": (id: string, captcha: string) => void;
+    "persistent data": (data: string) => void;
     "mqtt connect": () => void;
     "mqtt close": () => void;
     "mqtt lock message": (message: DeviceSmartLockMessage) => void;


### PR DESCRIPTION
For the Homey integration I would like to use config instead of a JSON file.
Some Homey devices do not have a disk were a file can be stored. But data can be persisted.

