### PR TITLE
FIX: remove api base from pic_url

### DIFF
--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -1457,9 +1457,11 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
                 if (device) {
                     const station = this.hubs[device.station_sn];
                     if (station) {
+                        // Remove API base from url.
+                        const strippedUrl = url.replace(/^.*\/\/[^\/]+/, '');
                         const response = await this.request({
                             method: "GET",
-                            endpoint: new URL(url),
+                            endpoint: strippedUrl,
                             responseType: "buffer"
                         });
                         if (response.status == 200) {

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -1458,7 +1458,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
                     const station = this.hubs[device.station_sn];
                     if (station) {
                         // Remove API base from url.
-                        const strippedUrl = url.replace(/^.*\/\/[^\/]+/, '');
+                        const strippedUrl = url.replace(/^.*\/\/[^\/]+\//, '');
                         const response = await this.request({
                             method: "GET",
                             endpoint: strippedUrl,

--- a/src/http/utils.ts
+++ b/src/http/utils.ts
@@ -496,8 +496,10 @@ export const getImagePath = function(path: string): string {
 };
 
 export const getImage = async function(api: HTTPApi, serial: string, url: string): Promise<Picture> {
+    // Remove API base from url.
+    const strippedUrl = url.replace(/^.*\/\/[^\/]+/, '');
     const { default: imageType } = await import("image-type");
-    const image = await api.getImage(serial, url);
+    const image = await api.getImage(serial, strippedUrl);
     const type = await imageType(image);
     return {
         data: image,

--- a/src/http/utils.ts
+++ b/src/http/utils.ts
@@ -496,10 +496,8 @@ export const getImagePath = function(path: string): string {
 };
 
 export const getImage = async function(api: HTTPApi, serial: string, url: string): Promise<Picture> {
-    // Remove API base from url.
-    const strippedUrl = url.replace(/^.*\/\/[^\/]+/, '');
     const { default: imageType } = await import("image-type");
-    const image = await api.getImage(serial, strippedUrl);
+    const image = await api.getImage(serial, url);
     const type = await imageType(image);
     return {
         data: image,


### PR DESCRIPTION
Due to the latest change the getImage function got a double apiBase in the url.

```
cause: HTTPError [EufyApiError]: 404 GET https://security-app.eufylife.com/https://security-app.eufylife.com/v1/s/g/nqza8PJjc
    404 page not found
```

This PR will fix the double API Base error