### PR TITLE
Solve TypeError in handleMsg

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -951,7 +951,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                     tmpSendQueue.forEach(element => {
                         this.sendQueue.push(element);
                     });
-                } else if (this.rawStation.devices !== undefined && this.rawStation.devices.length > 0 && Device.isLockWifiVideo(this.rawStation.devices[0].device_type)) {
+                } else if (this.rawStation.devices !== undefined && this.rawStation.devices !== null && this.rawStation.devices.length !== undefined && this.rawStation.devices.length > 0 && Device.isLockWifiVideo(this.rawStation.devices[0].device_type)) {
                     const tmpSendQueue: Array<P2PQueueMessage> = [ ...this.sendQueue ];
                     this.sendQueue = [];
                     const payload = buildVoidCommandPayload(255);


### PR DESCRIPTION
A user of the ccu-addon (based on the eufy-security-client from current development branch) was receiving the following error message:

```
/usr/local/addons/eufySecurity/eufySecurityApi/p2p/session.js
else if (this.rawStation.devices !== undefined && this.rawStation.devices.length > 0 && device_1.Device.isLockWifiVideo(this.rawStation.devices[0].device_type)) {
^
TypeError: Cannot read properties of null (reading 'length')
at P2PClientProtocol.handleMsg (/usr/local/addons/eufySecurity/eufySecurityApi/p2p/session.js)
at Socket.<anonymous> (/usr/local/addons/eufySecurity/eufySecurityApi/p2p/session.js)
at Socket.emit (node:events:518:28)
at Socket.emit (node:domain:488:12)
at UDP.onMessage [as onmessage] (node:dgram:941:8)
```

After extending the line to

```
} else if (this.rawStation.devices !== undefined && this.rawStation.devices !== null && this.rawStation.devices.length !== undefined && this.rawStation.devices.length > 0 && Device.isLockWifiVideo(this.rawStation.devices[0].device_type)) {
```

the problem was solved.

It may can be interesting, that the user uses a HomeBase 3, IndoorCam S350 and Video Doorbell Dual E340. Both of them are connected to the HB3 and were not operated standalone.