### PR TITLE
fix(bool): convert numeric to boolean

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -769,7 +769,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             } else if (property.type === "boolean") {
                 const booleanProperty = property as PropertyMetadataBoolean;
                 try {
-                    return value !== undefined ? (value === "1" || value.toLowerCase() === "true" ? true : false) : (booleanProperty.default !== undefined ? booleanProperty.default : false);
+                    return value !== undefined ? (typeof value === "number" ? !!value : (value === "1" || value.toLowerCase() === "true" ? true : false)) : (booleanProperty.default !== undefined ? booleanProperty.default : false);
                 } catch (err) {
                     const error = ensureError(err);
                     rootHTTPLogger.warn("Device convert raw property - PropertyMetadataBoolean Convert Error", { error: getError(error), deviceSN: this.getSerial(), property: property, value: value });


### PR DESCRIPTION
Looks like the Eufy API sometimes returns a numeric value for booleans. This PR adjust the boolean logic to update to use it.

It's also possible that open, delivery and masterpin uses more then a bool value and should be numeric.. Happy to adjust, just need to know how to grab that.


```
[http] [SmartDrop.convertRawPropertyValue] Device convert raw property - PropertyMetadataBoolean Convert Error {
  error: {
    cause: undefined,
    message: 'TypeError: value.toLowerCase is not a function',
    context: undefined,
    stacktrace: 'TypeError: value.toLowerCase is not a function\n' +
      '    at SmartDrop.convertRawPropertyValue (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:828:74)\n' +
      '    at SmartDrop.convertRawPropertyValue (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:1754:22)\n' +
      '    at SmartDrop.updateRawProperty (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:147:65)\n' +
      '    at /usr/src/app/node_modules/eufy-security-client/build/http/device.js:91:18\n' +
      '    at Array.forEach (<anonymous>)\n' +
      '    at SmartDrop.updateRawProperties (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:89:29)\n' +
      '    at /usr/src/app/node_modules/eufy-security-client/build/eufysecurity.js:822:20\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)'
  },
  deviceSN: 'T8790************',
  property: {
    key: 2105,
    name: 'open',
    label: 'Open',
    readable: true,
    writeable: false,
    type: 'boolean'
  },
  value: 0
}
2024-07-05 15:13:56.239	WARN	eufy-security-ws:eufy-security-client	[http] [SmartDrop.convertRawPropertyValue] Device convert raw property - PropertyMetadataBoolean Convert Error {
  error: {
    cause: undefined,
    message: 'TypeError: value.toLowerCase is not a function',
    context: undefined,
    stacktrace: 'TypeError: value.toLowerCase is not a function\n' +
      '    at SmartDrop.convertRawPropertyValue (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:828:74)\n' +
      '    at SmartDrop.convertRawPropertyValue (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:1754:22)\n' +
      '    at SmartDrop.updateRawProperty (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:147:65)\n' +
      '    at /usr/src/app/node_modules/eufy-security-client/build/http/device.js:91:18\n' +
      '    at Array.forEach (<anonymous>)\n' +
      '    at SmartDrop.updateRawProperties (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:89:29)\n' +
      '    at /usr/src/app/node_modules/eufy-security-client/build/eufysecurity.js:822:20\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)'
  },
  deviceSN: 'T8790************',
  property: {
    key: 2106,
    name: 'isDeliveryDenied',
    label: 'Is Delivery Denied',
    readable: true,
    writeable: false,
    type: 'boolean',
    default: false
  },
  value: 0
}
2024-07-05 15:13:56.242	WARN	eufy-security-ws:eufy-security-client	[http] [SmartDrop.convertRawPropertyValue] Device convert raw property - PropertyMetadataBoolean Convert Error {
  error: {
    cause: undefined,
    message: 'TypeError: value.toLowerCase is not a function',
    context: undefined,
    stacktrace: 'TypeError: value.toLowerCase is not a function\n' +
      '    at SmartDrop.convertRawPropertyValue (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:828:74)\n' +
      '    at SmartDrop.convertRawPropertyValue (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:1754:22)\n' +
      '    at SmartDrop.updateRawProperty (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:147:65)\n' +
      '    at /usr/src/app/node_modules/eufy-security-client/build/http/device.js:91:18\n' +
      '    at Array.forEach (<anonymous>)\n' +
      '    at SmartDrop.updateRawProperties (/usr/src/app/node_modules/eufy-security-client/build/http/device.js:89:29)\n' +
      '    at /usr/src/app/node_modules/eufy-security-client/build/eufysecurity.js:822:20\n' +
      '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)'
  },
  deviceSN: 'T8790************',
  property: {
    key: 2109,
    name: 'hasMasterPin',
    label: 'Has Master PIN',
    readable: true,
    writeable: false,
    type: 'boolean',
    default: false
  },
  value: 1
}
```