### PR TITLE
improved energy saving by omitting p2p connections

### DIFF
--- a/src/eufysecurity.ts
+++ b/src/eufysecurity.ts
@@ -66,6 +66,9 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
     private refreshEufySecurityP2PTimeout: {
         [dataType: string]: NodeJS.Timeout;
     } = {};
+    private refreshEufySecurityP2PEnergySavingOmitsCounter: {
+        [dataType: string]: number;
+    } = {};
     private deviceSnoozeTimeout: {
         [dataType: string]: NodeJS.Timeout;
     } = {};
@@ -132,6 +135,9 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
         }
         if (this.config.enableEmbeddedPKCS1Support === undefined) {
             this.config.enableEmbeddedPKCS1Support = false;
+        }
+        if (this.config.refreshP2PEnergySavingOmits === undefined) {
+            this.config.refreshP2PEnergySavingOmits = 2;
         }
         if(this.config.deviceConfig === undefined) {
             this.config.deviceConfig = {
@@ -327,6 +333,9 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
         if (serial && !Object.keys(this.stations).includes(serial)) {
             this.stations[serial] = station;
             this.getStorageInfo(serial);
+            if (station.isEnergySavingDevice()) {
+                this.refreshEufySecurityP2PEnergySavingOmitsCounter[serial] = 0;
+            }
             this.emit("station added", station);
         } else {
             rootMainLogger.debug(`Station with this serial ${station.getSerial()} exists already and couldn't be added again!`);
@@ -351,12 +360,34 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
             await this.stationsLoaded;
         if (Object.keys(this.stations).includes(hub.station_sn)) {
             this.stations[hub.station_sn].update(hub);
-            if (!this.stations[hub.station_sn].isConnected() && !this.stations[hub.station_sn].isEnergySavingDevice() && this.stations[hub.station_sn].isP2PConnectableDevice()) {
-                this.stations[hub.station_sn].setConnectionType(this.config.p2pConnectionSetup);
-                rootMainLogger.debug(`Updating station cloud data - initiate station connection to get local data over p2p`, { stationSN: hub.station_sn });
-                this.stations[hub.station_sn].connect();
+            if (this.stations[hub.station_sn].isP2PConnectableDevice()) {
+                if (!this.stations[hub.station_sn].isEnergySavingDevice() && !this.stations[hub.station_sn].isConnected()) {
+                    rootMainLogger.debug(`Updating station cloud data - initiate station connection to get local data over p2p`, { stationSN: hub.station_sn });
+                    this.stations[hub.station_sn].connect();
+                    this.getStorageInfo(hub.station_sn);
+                } else if (this.stations[hub.station_sn].isEnergySavingDevice() && !this.stations[hub.station_sn].isConnected()) {
+                    if (this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] === 0) {
+                        this.stations[hub.station_sn].setConnectionType(P2PConnectionType.QUICKEST);
+                        rootMainLogger.debug(`Updating station cloud data - initiate station connection to get local data over p2p`, { stationSN: hub.station_sn });
+                        this.stations[hub.station_sn].connect();
+                        this.getStorageInfo(hub.station_sn);
+                        if (this.config.refreshP2PEnergySavingOmits !== 0) {
+                            this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn]++;
+                        }
+                    } else if (this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] === this.config.refreshP2PEnergySavingOmits) {
+                        this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] = 0;
+                    } else if (this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] > 0 && this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] < 2) {
+                        this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn]++;
+                    } else {
+                        this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] = 0;
+                    }
+                } else if (this.stations[hub.station_sn].isConnected()) {
+                    this.getStorageInfo(hub.station_sn);
+                    if (this.stations[hub.station_sn].isEnergySavingDevice() && this.config.refreshP2PEnergySavingOmits !== 0) {
+                        this.refreshEufySecurityP2PEnergySavingOmitsCounter[hub.station_sn] = 1;
+                    }
+                }
             }
-            this.getStorageInfo(hub.station_sn);
         } else {
             rootMainLogger.debug(`Station with this serial ${hub.station_sn} doesn't exists and couldn't be updated!`);
         }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,6 +30,7 @@ export interface EufySecurityConfig {
     acceptInvitations?: boolean;
     stationIPAddresses?: StationIPAddresses;
     enableEmbeddedPKCS1Support?: boolean;
+    refreshP2PEnergySavingOmits?: number;
     deviceConfig?: {
         simultaneousDetections?: boolean;
     },


### PR DESCRIPTION
Hello @bropat,

with an energy saving device (esd) (in my case a T8170), I ran in the issue, that the device lost 10 to 20 percent of battery per day. Also for the esd, a p2p connection will be built up each 10 minutes. I did some investigation and have found the problem [here](https://github.com/bropat/eufy-security-client/blob/27e7c87d67810667022cf6cabb0c46ab1b818654/src/eufysecurity.ts#L359C13-L359C49). The `getStorageInfo` will build up a p2p connection, even if the device is not connected (like this is in the case of esd).

Because for the esd it is not necessary, I have changed the function, so that for these devices the p2p connection is omitted for a given value. If we use the standard value for `pollingIntervalMinutes` (10 minutes) and for (the new) `refreshP2PEnergySavingOmits` (2), the number of p2p connections will decrease from 6 to 2 per hour. The battery lost 2 to 6 percent per day.

Also I have implemented it in the way, if the esd is connected an this function is called, the counter is reset (the data has been updated, so the omits counter can start at 1). Anyway, by setting `refreshP2PEnergySavingOmits` to 0, the omits are disabled.

If you have any concerns or questions, please contact me.

Best, Philipp