### PR TITLE
Add missing entry for Wall Cam 81A0 battery

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -7493,6 +7493,7 @@ export const DeviceProperties: Properties = {
         [PropertyName.DeviceNotification]: DeviceNotificationWalllightProperty,
         [PropertyName.DeviceNotificationType]: DeviceNotificationTypeWalllightProperty,
         [PropertyName.DevicePowerWorkingMode]: DevicePowerWorkingModeProperty,
+        [PropertyName.DeviceBattery]: DeviceBatteryProperty,
     },
     [DeviceType.CAMERA_GARAGE_T8453]: {
         ...GenericDeviceProperties,


### PR DESCRIPTION
## Problem

The battery percentage sensor for my Wall Cam 81A0 does not show up in the Eufy Security integration, even though the battery percentage for this camera is visible in the official Eufy app.

## Investigation

I compared this camera's configuration with the configuration of other cameras for which I do have access to their battery percentage, and everything was in the right place, except for one missing entry: the `DeviceBatteryProperty` in the `DeviceType.WALL_LIGHT_CAM_81A0` array in types.ts.

## Fix

Add the missing entry

## Testing

Unable to test, but I did try, without any success. I wish there were instructions to quickly and easily test changes from eufy-security-client in my own Home Assistant. @bropat - It would be of great help for potential contributors, and for the growth of this rep, to have a small guide for local testing.