### PR TITLE
Fix get device serial

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -938,7 +938,7 @@ export class Station extends TypedEmitter<StationEvents> {
             }
         } else {
             const device_sn = this._getDeviceSerial(channel);
-            if (device_sn !== "") {
+            if (device_sn !== undefined) {
                 if (!devices[device_sn]) {
                     devices[device_sn] = {};
                 }

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -629,7 +629,10 @@ export class Station extends TypedEmitter<StationEvents> {
                 value: parsedValue,
                 source: "p2p"
             };
-            this.emit("raw device property changed", this._getDeviceSerial(channel), params);
+            let deviceSerial = this._getDeviceSerial(channel);
+            if (deviceSerial !== undefined) {
+                this.emit("raw device property changed", deviceSerial, params);
+            }
         }
     }
 
@@ -887,13 +890,29 @@ export class Station extends TypedEmitter<StationEvents> {
         return false;
     }*/
 
-    private _getDeviceSerial(channel: number): string {
-        if (this.rawStation.devices)
+    private _getDeviceSerial(channel: number): string | undefined {
+        if (this.rawStation.devices) {
+            // The station has attached devices (the normal case)
             for (const device of this.rawStation.devices) {
                 if (device.device_channel === channel)
                     return device.device_sn;
             }
-        return "";
+        } else {
+            // The station has no attached devices but there might be a device with the stations serial number (the special case)
+            // e.g. Smart Lock C220 (T8506)
+            const devices = this.api.getDevices();
+            if (devices) {
+                const device = devices[this.getSerial()];
+                if (device) {
+                    return this.getSerial();
+                } else {
+                    rootHTTPLogger.error(`Station get device serial - No device with the same serial number as the station found`, {station: this.getSerial(), channel: channel});
+                }
+            } else {
+                rootHTTPLogger.error(`Station get device serial - No devices found`, {station: this.getSerial(), channel: channel});
+            }
+        }
+        return undefined;
     }
 
     private _handleCameraInfoParameters(devices: { [index: string]: RawValues; }, channel: number, type: number, value: string): void {
@@ -8304,23 +8323,38 @@ export class Station extends TypedEmitter<StationEvents> {
     }
 
     private onDeviceShakeAlarm(channel: number, event: SmartSafeShakeAlarmEvent): void {
-        this.emit("device shake alarm", this._getDeviceSerial(channel), event);
+        const deviceSerial = this._getDeviceSerial(channel);
+        if (deviceSerial !== undefined) {
+            this.emit("device shake alarm", deviceSerial, event);
+        }
     }
 
     private onDevice911Alarm(channel: number, event: SmartSafeAlarm911Event): void {
-        this.emit("device 911 alarm", this._getDeviceSerial(channel), event);
+        const deviceSerial = this._getDeviceSerial(channel);
+        if (deviceSerial !== undefined) {
+            this.emit("device 911 alarm", deviceSerial, event);
+        }
     }
 
     private onDeviceJammed(channel: number): void {
-        this.emit("device jammed", this._getDeviceSerial(channel));
+        const deviceSerial = this._getDeviceSerial(channel);
+        if (deviceSerial !== undefined) {
+            this.emit("device jammed", deviceSerial);
+        }
     }
 
     private onDeviceLowBattery(channel: number): void {
-        this.emit("device low battery", this._getDeviceSerial(channel));
+        const deviceSerial = this._getDeviceSerial(channel);
+        if (deviceSerial !== undefined) {
+            this.emit("device low battery", deviceSerial);
+        }
     }
 
     private onDeviceWrongTryProtectAlarm(channel: number): void {
-        this.emit("device wrong try-protect alarm", this._getDeviceSerial(channel));
+        const deviceSerial = this._getDeviceSerial(channel);
+        if (deviceSerial !== undefined) {
+            this.emit("device wrong try-protect alarm", deviceSerial);
+        }
     }
 
     private onSdInfoEx(sdStatus: number, sdCapacity: number, sdAvailableCapacity: number): void {

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1905,7 +1905,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                                                         this.emit("secondary command", result);
                                                         delete this.customDataStaging[commandType];
                                                     }
-                                                    rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - CMD_NOTIFY_PAYLOAD Smart Lock  return code: ${returnCode}`, { stationSN: this.rawStation.station_sn, commandIdName: CommandType[json.cmd], commandId: json.cmd, decoded: data.toString("hex"), bleCommandCode: functionTypeCommand[fac.getCommandCode()!], returnCode: returnCode });
+                                                    rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - CMD_NOTIFY_PAYLOAD Smart Lock  return code: ${returnCode}`, { stationSN: this.rawStation.station_sn, commandIdName: CommandType[json.cmd], commandId: json.cmd, decoded: data.toString("hex"), bleCommandCode: functionTypeCommand[fac.getCommandCode()!], returnCode: returnCode, channel: message.channel });
                                                     const parsePayload = new ParsePayload(data.subarray(1));
                                                     if (fac.getDataType() === SmartLockFunctionType.TYPE_2) {
                                                         switch (fac.getCommandCode()) {


### PR DESCRIPTION
This refs to #668.

The lock T8806 has a station and a device. In contrast to the devices I know so far, the locks station has no devices in the devices array. So, I changed the `_getDeviceSerial` function to retrieve also the serial of the device of these stations to update the properties correctly.
