### PR TITLE
Add DeviceTriggerAlarmSound command for floodlight camera T8425 (E340)

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -9651,6 +9651,7 @@ export const DeviceCommands: Commands = {
         CommandName.DevicePresetPosition,
         CommandName.DeviceSavePresetPosition,
         CommandName.DeviceDeletePresetPosition,
+        CommandName.DeviceTriggerAlarmSound,
     ],
     [DeviceType.FLOODLIGHT_CAMERA_8426]: [
         CommandName.DeviceStartLivestream,


### PR DESCRIPTION
The Floodlight Cam E340 (Model 8425) supports DeviceTriggerAlarmSound. I tested this on my devices. Works fine.