### PR TITLE
Updated pan, tilt, and preset commands for SOLO_CAMERA_E30 (T8171)

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -9591,11 +9591,17 @@ export const DeviceCommands: Commands = {
     [DeviceType.SOLO_CAMERA_E30]: [
         CommandName.DeviceStartLivestream,
         CommandName.DeviceStopLivestream,
+        CommandName.DevicePanAndTilt,
         CommandName.DeviceStartDownload,
         CommandName.DeviceCancelDownload,
+        CommandName.DeviceCalibrate,
         CommandName.DeviceStartTalkback,
         CommandName.DeviceStopTalkback,
         CommandName.DeviceSnooze,
+        CommandName.DevicePresetPosition,
+        CommandName.DeviceSavePresetPosition,
+        CommandName.DeviceDeletePresetPosition,
+        CommandName.DeviceTriggerAlarmSound,
     ],
     [DeviceType.FLOODLIGHT]: [
         CommandName.DeviceStartLivestream,


### PR DESCRIPTION
Added support for pan, tilt, and preset commands for SOLO_CAMERA_E30 (T8171)

This camera can pan, tilt and also have presents positions.