### PR TITLE
Migrate from date-and-time 3.x to 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eufy-security-client",
-  "version": "3.2.0",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eufy-security-client",
-      "version": "3.2.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.2.0",
@@ -30,7 +30,6 @@
       },
       "devDependencies": {
         "@types/crypto-js": "^4.2.2",
-        "@types/fs-extra": "^11.0.4",
         "@types/node": "^20.16.10",
         "@types/node-rsa": "^1.1.4",
         "@types/node-schedule": "^2.1.7",
@@ -284,30 +283,11 @@
       "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
       "dev": true
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "license": "MIT"
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
-      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.16.10",
@@ -3267,29 +3247,10 @@
       "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
       "dev": true
     },
-    "@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "requires": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
-    },
-    "@types/jsonfile": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
-      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/node": {
       "version": "20.16.10",

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -1,6 +1,6 @@
 import { TypedEmitter } from "tiny-typed-emitter";
 import { Readable } from "stream";
-import date from "date-and-time";
+const { format } = require('date-and-time');
 
 import { HTTPApi } from "./api";
 import { AlarmMode, AlarmTone, NotificationSwitchMode, DeviceType, FloodlightMotionTriggeredDistance, GuardMode, NotificationType, ParamType, PowerSource, PropertyName, StationProperties, TimeFormat, CommandName, StationCommands, StationGuardModeKeyPadProperty, StationCurrentModeKeyPadProperty, StationAutoEndAlarmProperty, StationSwitchModeWithAccessCodeProperty, StationTurnOffAlarmWithButtonProperty, PublicKeyType, MotionDetectionMode, VideoTypeStoreToNAS, HB3DetectionTypes, WalllightNotificationType, DailyLightingType, MotionActivationMode, BaseStationProperties, LightingActiveMode, SourceType, T8170DetectionTypes, IndoorS350NotificationTypes, SoloCameraDetectionTypes, MotionDetectionRangeType, ViewModeType, FloodlightT8425NotificationTypes, PresetPositionType, SmartLockNotification, IndoorS350DetectionTypes } from "./types";
@@ -9648,12 +9648,12 @@ export class Station extends TypedEmitter<StationEvents> {
                         "count": 20,
                         "detection_type": detectionType,
                         "device_info": devices,
-                        "end_date": date.format(endDate, "YYYYMMDD"),
+                        "end_date": format(endDate, "YYYYMMDD"),
                         "event_type": eventType,
                         "flag": 0,
                         "res_unzip": 1,
-                        "start_date": date.format(startDate, "YYYYMMDD"),
-                        "start_time": `${date.format(endDate, "YYYYMMDD")}000000`,
+                        "start_date": format(startDate, "YYYYMMDD"),
+                        "start_time": `${format(endDate, "YYYYMMDD")}000000`,
                         "storage_cloud": storageType === FilterStorageType.NONE || (storageType !== FilterStorageType.LOCAL && storageType !== FilterStorageType.CLOUD) ? -1 : storageType,
                         "ai_type": 0
                     },
@@ -9724,8 +9724,8 @@ export class Station extends TypedEmitter<StationEvents> {
                 "payload": {
                     "cmd": CommandType.CMD_DATABASE_COUNT_BY_DATE,
                     "payload": {
-                        "end_date": date.format(endDate, "YYYYMMDD"),
-                        "start_date": date.format(startDate, "YYYYMMDD"),
+                        "end_date": format(endDate, "YYYYMMDD"),
+                        "start_date": format(startDate, "YYYYMMDD"),
                     },
                     "table": "history_record_info",
                     "transaction": `${new Date().getTime()}`

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -3,7 +3,7 @@ import { TypedEmitter } from "tiny-typed-emitter";
 import * as NodeRSA from "node-rsa";
 import { Readable } from "stream";
 import { SortedMap } from "sweet-collections";
-import date from "date-and-time";
+const { parse } = require('date-and-time');
 
 import { Address, CmdCameraInfoResponse, CmdNotifyPayload, CommandResult, ESLAdvancedLockStatusNotification, ESLStationP2PThroughData, SmartSafeSettingsNotification, SmartSafeStatusNotification, CustomData, ESLBleV12P2PThroughData, CmdDatabaseImageResponse, EntrySensorStatus, GarageDoorStatus, StorageInfoHB3, ESLAdvancedLockStatusNotificationT8530, SmartLockP2PThroughData, SmartLockP2PSequenceData } from "./models";
 import { sendMessage, hasHeader, buildCheckCamPayload, buildIntCommandPayload, buildIntStringCommandPayload, buildCommandHeader, MAGIC_WORD, buildCommandWithStringTypePayload, isPrivateIp, buildLookupWithKeyPayload, sortP2PMessageParts, buildStringTypeCommandPayload, getRSAPrivateKey, decryptAESData, getNewRSAPrivateKey, findStartCode, isIFrame, generateLockSequence, decodeLockPayload, generateBasicLockAESKey, getLockVectorBytes, decryptLockAESData, buildLookupWithKeyPayload2, buildCheckCamPayload2, buildLookupWithKeyPayload3, decodeBase64, getVideoCodec, checkT8420, buildVoidCommandPayload, isP2PQueueMessage, buildTalkbackAudioFrameHeader, getLocalIpAddress, decodeP2PCloudIPs, decodeSmartSafeData, decryptPayloadData, decryptP2PData, getP2PCommandEncryptionKey, getNullTerminatedString, generateSmartLockAESKey, readNullTerminatedBuffer } from "./utils";
@@ -2172,7 +2172,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                                 const result: Array<DatabaseCountByDate> = [];
                                 for (const record of data) {
                                     result.push({
-                                        day: date.parse(record.days, "YYYYMMDD"),
+                                        day: parse(record.days, "YYYYMMDD"),
                                         count: record.count
                                     });
                                 }
@@ -2198,8 +2198,8 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                                             tmpRecord.history = {
                                                 device_type: (tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).device_type,
                                                 account: (tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).account,
-                                                start_time: date.parse((tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).start_time, "YYYY-MM-DD HH:mm:ss"),
-                                                end_time: date.parse((tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).end_time, "YYYY-MM-DD HH:mm:ss"),
+                                                start_time: parse((tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).start_time, "YYYY-MM-DD HH:mm:ss"),
+                                                end_time: parse((tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).end_time, "YYYY-MM-DD HH:mm:ss"),
                                                 frame_num: (tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).frame_num,
                                                 storage_type: (tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).storage_type,
                                                 storage_cloud: (tableRecord as P2PDatabaseQueryLocalHistoryRecordInfo).storage_cloud,
@@ -2236,13 +2236,13 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                                                 detection_type: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).detection_type,
                                                 person_id: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).person_id,
                                                 crop_path: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).crop_path,
-                                                event_time: date.parse((tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).event_time, "YYYY-MM-DD HH:mm:ss"),
+                                                event_time: parse((tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).event_time, "YYYY-MM-DD HH:mm:ss"),
                                                 person_recog_flag: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).person_recog_flag,
                                                 crop_pic_quality: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).crop_pic_quality,
                                                 pic_marking_flag: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).pic_marking_flag,
                                                 group_id: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).group_id,
                                                 crop_id: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).crop_id,
-                                                start_time: date.parse((tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).start_time, "YYYY-MM-DD HH:mm:ss"),
+                                                start_time: parse((tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).start_time, "YYYY-MM-DD HH:mm:ss"),
                                                 storage_type: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).storage_type,
                                                 storage_status: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).storage_status,
                                                 storage_label: (tableRecord as P2PDatabaseQueryLocalRecordCropPictureInfo).storage_label,


### PR DESCRIPTION
The new version has been rewritten and we needed to follow the migration to fully support it.

https://github.com/knowledgecode/date-and-time/blob/master/docs/migration.md