### PR TITLE
fix changed build directory structure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { version } from '../package.json';
-
 export * from "./http";
 export * from "./p2p";
 export * from "./push";
@@ -8,5 +6,5 @@ export * from "./eufysecurity";
 export * from "./error";
 export { LoggingCategories, LogLevel, Logger, dummyLogger } from "./logging";
 
-
+const version: string = require("../package.json").version;
 export const libVersion: string = version


### PR DESCRIPTION
Fix: Replace ES module import with require for package.json version

Using ES module import syntax to read package.json version resulted in incompatible build output that broke consumption by downstream packages. Switched to require() to restore correct build behavior.