### PR TITLE
fixing T8410 not possible disable or enable

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -1188,8 +1188,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
             type == DeviceType.INDOOR_PT_CAMERA_E30 ||
             type == DeviceType.INDOOR_PT_CAMERA_C210 ||
             type == DeviceType.INDOOR_PT_CAMERA_C220 ||
-            type == DeviceType.INDOOR_PT_CAMERA_C220_V2 ||
-            type == DeviceType.INDOOR_PT_CAMERA)
+            type == DeviceType.INDOOR_PT_CAMERA_C220_V2)
             return true;
         return false;
     }
@@ -1410,6 +1409,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     static isIndoorCamMini(type: number): boolean {
         return DeviceType.INDOOR_COST_DOWN_CAMERA == type;
+    }
+
+    static isIndoorCamC24(type: number): boolean {
+        return DeviceType.INDOOR_PT_CAMERA == type;
     }
 
     static isCamera1Product(type: number): boolean {
@@ -1781,6 +1784,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
     public isIndoorCamMini(): boolean {
         return Device.isIndoorCamMini(this.rawDevice.device_type);
+    }
+
+    public isIndoorCamC24(): boolean {
+        return Device.isIndoorCamC24(this.rawDevice.device_type);
     }
 
     public isSoloCameras(): boolean {

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -4901,7 +4901,7 @@ export class Station extends TypedEmitter<StationEvents> {
             }, {
                 command: commandData
             });
-        } else if ((device.isIndoorPanAndTiltCameraS350() && this.isStationHomeBase3()) || device.isFloodLightT8425()) {
+        } else if (((device.isIndoorPanAndTiltCameraS350() || device.isIndoorCamC24()) && this.isStationHomeBase3()) || device.isFloodLightT8425()) {
             rootHTTPLogger.debug(`Station start livestream - sending command using CMD_SET_PAYLOAD`, { stationSN: this.getSerial(), deviceSN: device.getSerial(), videoCodec: videoCodec, main_sw_version: this.getSoftwareVersion() });
             this.p2pSession.sendCommandWithStringPayload({
                 commandType: CommandType.CMD_SET_PAYLOAD,


### PR DESCRIPTION
Fixes the possibility to disable and enable the T8410 device (see #750).

Hopefully keeping the fix from #723. It would be great if @waringer have the time to check this.