### PR TITLE
Add preset support for C210

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -9614,6 +9614,9 @@ export const DeviceCommands: Commands = {
         CommandName.DeviceStartTalkback,
         CommandName.DeviceStopTalkback,
         CommandName.DeviceSnooze,
+        CommandName.DevicePresetPosition,
+        CommandName.DeviceSavePresetPosition,
+        CommandName.DeviceDeletePresetPosition,
     ],
     [DeviceType.INDOOR_PT_CAMERA_C220]: [
         CommandName.DeviceStartLivestream,


### PR DESCRIPTION
Minimal change for functionality: adds the preset commands to the INDOOR_PT_CAMERA_C210 device type.

I didn't add a method `isIndoorPanAndTiltCameraC210`, because `isIndoorPanAndTiltCameraS350` already includes the C210 model and thus the preset support works without this method being added.

Used #638 for reference.