### PR TITLE
fix: HB3 video download returns -104 ERROR_INVALID_ACCOUNT

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -7439,11 +7439,10 @@ export class Station extends TypedEmitter<StationEvents> {
       cipherID: cipher_id,
     });
     if (this.getDeviceType() === DeviceType.HB3) {
-      //TODO: Implement HB3 Support! Actually doesn't work and returns return_code -104 (ERROR_INVALID_ACCOUNT). It could be that we need the new encrypted p2p protocol to make this work...
       const rsa_key = this.p2pSession.getDownloadRSAPrivateKey();
       this.p2pSession.sendCommandWithStringPayload(
         {
-          commandType: CommandType.CMD_DOWNLOAD_VIDEO,
+          commandType: CommandType.CMD_SET_PAYLOAD,
           value: JSON.stringify({
             account_id: this.rawStation.member.admin_user_id,
             cmd: CommandType.CMD_DOWNLOAD_VIDEO,

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1113,7 +1113,11 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
         this.currentMessageState[P2PDataType.VIDEO].p2pStreaming = true;
         this.currentMessageState[P2PDataType.VIDEO].p2pStreamChannel = messageState.channel;
         this.waitForStreamData(P2PDataType.VIDEO);
-      } else if (messageState.commandType === CommandType.CMD_DOWNLOAD_VIDEO) {
+      } else if (
+        messageState.commandType === CommandType.CMD_DOWNLOAD_VIDEO ||
+        (messageState.nestedCommandType === CommandType.CMD_DOWNLOAD_VIDEO &&
+          messageState.commandType === CommandType.CMD_SET_PAYLOAD)
+      ) {
         if (
           this.currentMessageState[P2PDataType.BINARY].p2pStreaming &&
           messageState.channel !== this.currentMessageState[P2PDataType.BINARY].p2pStreamChannel
@@ -2603,7 +2607,10 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
           });
           this.downloadTotalBytes = totalBytes;
           this.currentMessageState[P2PDataType.BINARY].p2pStreaming = true;
-          this.currentMessageState[P2PDataType.BINARY].p2pStreamChannel = message.channel;
+          // HB3 sends channel 255 (broadcast) which is not a valid device channel
+          if (message.channel !== 255) {
+            this.currentMessageState[P2PDataType.BINARY].p2pStreamChannel = message.channel;
+          }
           break;
         case CommandType.CMD_WIFI_CONFIG:
           const rssi = data.readInt32LE();


### PR DESCRIPTION
## Description

Fixes video download for HomeBase 3 (HB3) devices which currently returns error code -104 (ERROR_INVALID_ACCOUNT).

The existing code has a TODO comment acknowledging this issue:
> "TODO: Implement HB3 Support! Actually doesn't work and returns return_code -104 (ERROR_INVALID_ACCOUNT). It could be that we need the new encrypted p2p protocol to make this work..."

### Root Cause

The HB3 requires `CMD_SET_PAYLOAD` as the command wrapper (like other HB3 commands such as `setGuardMode`, `getStorageInfo`), but the download code was using `CMD_DOWNLOAD_VIDEO` directly.

### The Fix

**station.ts** - Single line change in `startDownload()` method:
```diff
  this.p2pSession.sendCommandWithStringPayload({
-     commandType: CommandType.CMD_DOWNLOAD_VIDEO,
+     commandType: CommandType.CMD_SET_PAYLOAD,
      value: JSON.stringify({
          // ... payload unchanged
      }),
```

**session.ts** - Two fixes for HB3 channel handling:

1. **Set channel when download command is sent** (follows livestream pattern):
```diff
- } else if (messageState.commandType === CommandType.CMD_DOWNLOAD_VIDEO) {
+ } else if (messageState.commandType === CommandType.CMD_DOWNLOAD_VIDEO ||
+     (messageState.commandType === CommandType.CMD_SET_PAYLOAD && messageState.nestedCommandType === CommandType.CMD_DOWNLOAD_VIDEO)) {
```

2. **Ignore channel 255 in `CMD_CONVERT_MP4_OK`**:

HB3 sends `channel=255` (broadcast address) which would overwrite the correct channel.

```diff
  case CommandType.CMD_CONVERT_MP4_OK:
-     this.currentMessageState[P2PDataType.BINARY].p2pStreamChannel = message.channel;
+     if (message.channel !== 255) {
+         this.currentMessageState[P2PDataType.BINARY].p2pStreamChannel = message.channel;
+     }
```

## Testing

Tested on:
- **Station**: HomeBase 3 (T8030), firmware 3.7.3.6
- **Camera**: Video Doorbell S220 (T8210C), firmware 3.0.8.2
- **Camera**: SoloCam S340 (T8170), firmware 3.3.0.0
- **eufy-security-client**: 3.4.0

### Before
```
→ device.start_download
← command result: ERROR_INVALID_ACCOUNT (-104)
```

### After
```
→ device.start_download
← command result: ERROR_PPCS_SUCCESSFUL (0)
← download started
← download finished
```

Test results:
- Video: 
  - T8210C: H.264 High, 2048x1536
  - T8170: HEVC Main, 2880x1616
- Audio: AAC LC, 16kHz mono

## Related Issues

- Addresses TODO comment in `src/http/station.ts`
- Related to #358
- Related to #395

## Checklist

- [x] Code follows project style guidelines
- [x] TypeScript compiles without errors
- [x] Tested with real HB3 hardware
- [x] No breaking changes to existing functionality
- [x] Updated documentation if needed (N/A - bug fix for existing feature)