### PR TITLE
Add placeholder eufyCam S4 support

### DIFF
--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -82,6 +82,7 @@
 | ![T87B0 image](_media/smarttrack_link_t87B0_small.jpg) | SmartTrack Link (T87B0) | :heavy_check_mark: | Firmware: 1.5.6 (20231012) |
 | ![T87B2 image](_media/smarttrack_card_t87B2_small.jpg) | SmartTrack Card (T87B2) | :heavy_exclamation_mark: |  |
 
+| ![T8?? image](_media/eufycam_s4_small.jpg) | eufyCam S4 (T8??) | :heavy_exclamation_mark: | 
 ## Legend
 
 | Icon | Description |

--- a/src/http/const.ts
+++ b/src/http/const.ts
@@ -4479,6 +4479,8 @@ export const PhoneModels: Array<string> = [
     "SM-S357BL",
     "SM-S367VL",
     "SM-S426DL",
+    "EUFY-S4-01",
+    "EUFY-S4-02"
     "SM-S506DL",
     "SM-S515DL",
     "SM-S536DL",


### PR DESCRIPTION
This PR adds a placeholder entry for the eufyCam S4 in the supported devices table and inserts placeholder model identifiers in the cloud‑model list. The implementation can be refined once the exact model codes and parameters are known.