### PR TITLE
Fix T8214 and T8425 livestream

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -2523,9 +2523,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
       sn.startsWith("T8172") ||
       sn.startsWith("T8173") ||
       sn.startsWith("T86P2") ||
+      sn.startsWith("T8214") ||
       sn.startsWith("T8422") ||
       sn.startsWith("T8423") ||
       sn.startsWith("T8424") ||
+      sn.startsWith("T8425") ||
       sn.startsWith("T8426") ||
       sn.startsWith("T8440") ||
       sn.startsWith("T8441") ||

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -2852,6 +2852,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
     return Device.isCamera2CPro(this.rawDevice.device_type);
   }
 
+  public isCameraE40(): boolean {
+    return Device.isCameraE40(this.rawDevice.device_type);
+  }
+
   public isCamera2Product(): boolean {
     return Device.isCamera2Product(this.rawDevice.device_type);
   }

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -7658,7 +7658,7 @@ export class Station extends TypedEmitter<StationEvents> {
           command: commandData,
         }
       );
-    } else if (device.isOutdoorPanAndTiltCamera()) {
+    } else if (device.isOutdoorPanAndTiltCamera() || device.isBatteryDoorbellDualE340() || device.isFloodLightT8425()) {
       rootHTTPLogger.debug(`Station start livestream - sending command using CMD_DOORBELL_SET_PAYLOAD (1)`, {
         stationSN: this.getSerial(),
         deviceSN: device.getSerial(),
@@ -7717,8 +7717,7 @@ export class Station extends TypedEmitter<StationEvents> {
         }
       );
     } else if (
-      ((device.isIndoorPanAndTiltCameraS350() || device.isIndoorCamC24()) && this.isDeviceControlledByHomeBase()) ||
-      device.isFloodLightT8425()
+      ((device.isIndoorPanAndTiltCameraS350() || device.isIndoorCamC24()) && this.isDeviceControlledByHomeBase())
     ) {
       rootHTTPLogger.debug(`Station start livestream - sending command using CMD_SET_PAYLOAD`, {
         stationSN: this.getSerial(),


### PR DESCRIPTION
# Fix T8214 and T8425 livestream

## Summary

Livestream is broken on T8214 (Battery Doorbell Plus E340) and T8425 (Floodlight Camera) because both devices are missing from the integrated device list and are routed through the wrong livestream command path.

This is a **device-gated only** subset of the reverted #779 — no session, encryption, or generic code path changes.

## What was wrong

- T8214 and T8425 were not registered as integrated P2P devices, so commands were not routed through the station.
- Both devices need `CMD_DOORBELL_SET_PAYLOAD` for livestream (same as the Outdoor Pan & Tilt Camera), but T8425 was incorrectly routed through `CMD_SET_PAYLOAD`.

## What this PR does

1. Registers T8214 and T8425 in `isIntegratedDeviceBySn` for correct P2P routing.
2. Routes T8214 and T8425 livestream through `CMD_DOORBELL_SET_PAYLOAD`.
3. Adds missing `isCameraE40()` instance method (static existed but instance wrapper was missing).

## Testing

Livestream not tested end-to-end on both T8214 and T8425.