### PR TITLE
Enable ECDH encryption for T8214 and T8425 P2P sessions

### DIFF
--- a/src/http/models.ts
+++ b/src/http/models.ts
@@ -400,6 +400,7 @@ export interface Cipher {
   cipher_id: number;
   user_id: string;
   private_key: string;
+  ecc_private_key?: string;
 }
 
 export interface Voice {

--- a/src/p2p/__test__/utils.test.tsx
+++ b/src/p2p/__test__/utils.test.tsx
@@ -35,8 +35,11 @@ import {
     MAGIC_WORD,
     generateBasicLockAESKey,
     eufyKDF,
+    decryptP2PKeyECDH,
+    getLockV12Key,
 } from "../utils";
 import { VideoCodec } from "../types";
+import { createECDH } from "crypto";
 
 jest.mock("../../logging", () => ({
     rootP2PLogger: { error: jest.fn(), debug: jest.fn(), info: jest.fn() },
@@ -635,6 +638,59 @@ describe("p2p/utils", () => {
             const result = readNullTerminatedBuffer(input);
             input[0] = 0x00;
             expect(result[0]).toBe(0x41);
+        });
+    });
+
+    describe("decryptP2PKeyECDH", () => {
+        const device = createECDH("prime256v1");
+        device.generateKeys();
+        const eccPrivateKey = device.getPrivateKey("hex");
+
+        it("should decrypt with compressed pubkey only", () => {
+            const peer = createECDH("prime256v1");
+            peer.generateKeys();
+
+            const result = decryptP2PKeyECDH(Buffer.from(peer.getPublicKey("hex", "compressed"), "hex"), eccPrivateKey);
+            expect(result).toEqual(device.computeSecret(peer.getPublicKey()).subarray(0, 16));
+        });
+
+        it("should decrypt with uncompressed pubkey only", () => {
+            const peer = createECDH("prime256v1");
+            peer.generateKeys();
+
+            const result = decryptP2PKeyECDH(peer.getPublicKey(), eccPrivateKey);
+            expect(result).toEqual(device.computeSecret(peer.getPublicKey()).subarray(0, 16));
+        });
+
+        it("should decrypt ECIES envelope", () => {
+            const sessionKey = "0123456789abcdef0123456789abcdef";
+            const envelope = Buffer.from(getLockV12Key(sessionKey, device.getPublicKey("hex").substring(2)), "hex");
+
+            expect(decryptP2PKeyECDH(envelope, eccPrivateKey)).toEqual(Buffer.from(sessionKey, "hex"));
+        });
+
+        it("should decrypt 48-byte ECIES payload", () => {
+            const plaintext = Buffer.alloc(48, 0xab).toString("hex");
+            const envelope = Buffer.from(getLockV12Key(plaintext, device.getPublicKey("hex").substring(2)), "hex");
+
+            expect(decryptP2PKeyECDH(envelope, eccPrivateKey)).toEqual(Buffer.from(plaintext, "hex").subarray(0, 16));
+        });
+
+        it("should always return 16 bytes", () => {
+            const peer = createECDH("prime256v1");
+            peer.generateKeys();
+
+            const result = decryptP2PKeyECDH(Buffer.from(peer.getPublicKey("hex", "compressed"), "hex"), eccPrivateKey);
+            expect(Buffer.isBuffer(result)).toBe(true);
+            expect(result.length).toBe(16);
+        });
+
+        it("should produce deterministic output", () => {
+            const peer = createECDH("prime256v1");
+            peer.generateKeys();
+            const pub = Buffer.from(peer.getPublicKey("hex", "compressed"), "hex");
+
+            expect(decryptP2PKeyECDH(pub, eccPrivateKey)).toEqual(decryptP2PKeyECDH(pub, eccPrivateKey));
         });
     });
 });

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1886,23 +1886,34 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
         let return_code = 0;
         let resultData: Buffer | undefined;
         if (message.bytesToRead > 0) {
-          if (message.signCode > 0) {
-            try {
-              message.data = decryptP2PData(message.data, this.p2pKey!);
-            } catch (err) {
-              const error = ensureError(err);
-              rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - Decrypt Error`, {
-                error: getError(error),
+          if (message.signCode > 0 && message.data.length > 0) {
+            if (message.data.length % 16 === 0) {
+              try {
+                message.data = decryptP2PData(message.data, this.p2pKey!);
+              } catch (err) {
+                const error = ensureError(err);
+                rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - Decrypt Error`, {
+                  error: getError(error),
+                  stationSN: this.rawStation.station_sn,
+                  message: {
+                    seqNo: message.seqNo,
+                    channel: message.channel,
+                    commandType: CommandType[message.commandId],
+                    signCode: message.signCode,
+                    type: message.type,
+                    dataType: P2PDataType[message.dataType],
+                    data: message.data.toString("hex"),
+                  },
+                });
+              }
+            } else {
+              rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - Skipping decryption, data not block-aligned`, {
                 stationSN: this.rawStation.station_sn,
-                message: {
-                  seqNo: message.seqNo,
-                  channel: message.channel,
-                  commandType: CommandType[message.commandId],
-                  signCode: message.signCode,
-                  type: message.type,
-                  dataType: P2PDataType[message.dataType],
-                  data: message.data.toString("hex"),
-                },
+                seqNo: message.seqNo,
+                commandType: CommandType[message.commandId],
+                signCode: message.signCode,
+                dataLength: message.data.length,
+                mod16: message.data.length % 16,
               });
             }
           }

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -1907,14 +1907,17 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                 });
               }
             } else {
-              rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - Skipping decryption, data not block-aligned`, {
-                stationSN: this.rawStation.station_sn,
-                seqNo: message.seqNo,
-                commandType: CommandType[message.commandId],
-                signCode: message.signCode,
-                dataLength: message.data.length,
-                mod16: message.data.length % 16,
-              });
+              rootP2PLogger.debug(
+                `Handle DATA ${P2PDataType[message.dataType]} - Skipping decryption, data not block-aligned`,
+                {
+                  stationSN: this.rawStation.station_sn,
+                  seqNo: message.seqNo,
+                  commandType: CommandType[message.commandId],
+                  signCode: message.signCode,
+                  dataLength: message.data.length,
+                  mod16: message.data.length % 16,
+                }
+              );
             }
           }
           return_code = message.data.subarray(0, 4).readUInt32LE() | 0;
@@ -4046,7 +4049,8 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
           // Keep full raw buffer for ECDH — readNullTerminatedBuffer truncates binary ECIES envelopes at 0x00 bytes
           const rawEncryptedKey = data.subarray(4);
           const encryptedKey = readNullTerminatedBuffer(rawEncryptedKey);
-          const isECDHDevice = this.rawStation.station_sn.startsWith("T8214") || this.rawStation.station_sn.startsWith("T8425");
+          const isECDHDevice =
+            this.rawStation.station_sn.startsWith("T8214") || this.rawStation.station_sn.startsWith("T8425");
           this.api
             .getCipher(/*this.rawStation.station_sn, */ cipherID, this.rawStation.member.admin_user_id)
             .then((cipher) => {

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -66,6 +66,7 @@ import {
   getNullTerminatedString,
   generateSmartLockAESKey,
   readNullTerminatedBuffer,
+  decryptP2PKeyECDH,
 } from "./utils";
 import {
   RequestMessageType,
@@ -4031,7 +4032,10 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
             data: data.toString("hex"),
             cipherID: cipherID,
           });
-          const encryptedKey = readNullTerminatedBuffer(data.subarray(4));
+          // Keep full raw buffer for ECDH — readNullTerminatedBuffer truncates binary ECIES envelopes at 0x00 bytes
+          const rawEncryptedKey = data.subarray(4);
+          const encryptedKey = readNullTerminatedBuffer(rawEncryptedKey);
+          const isECDHDevice = this.rawStation.station_sn.startsWith("T8214") || this.rawStation.station_sn.startsWith("T8425");
           this.api
             .getCipher(/*this.rawStation.station_sn, */ cipherID, this.rawStation.member.admin_user_id)
             .then((cipher) => {
@@ -4046,13 +4050,66 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                 }
               );
               if (cipher !== undefined) {
-                this.encryption = EncryptionType.LEVEL_2;
-                const rsa = getRSAPrivateKey(cipher.private_key, this.enableEmbeddedPKCS1Support);
-                this.p2pKey = rsa.decrypt(encryptedKey);
-                rootP2PLogger.debug(
-                  `Handle DATA ${P2PDataType[message.dataType]} - CMD_GATEWAYINFO - set encryption level 2`,
-                  { stationSN: this.rawStation.station_sn, key: this.p2pKey.toString("hex") }
-                );
+                // Try RSA first
+                try {
+                  this.encryption = EncryptionType.LEVEL_2;
+                  const rsa = getRSAPrivateKey(cipher.private_key, this.enableEmbeddedPKCS1Support);
+                  this.p2pKey = rsa.decrypt(encryptedKey);
+                  rootP2PLogger.debug(
+                    `Handle DATA ${P2PDataType[message.dataType]} - CMD_GATEWAYINFO - RSA success - set encryption level 2`,
+                    { stationSN: this.rawStation.station_sn, key: this.p2pKey.toString("hex") }
+                  );
+                } catch (rsaErr) {
+                  const rsaError = ensureError(rsaErr);
+                  rootP2PLogger.debug(
+                    `Handle DATA ${P2PDataType[message.dataType]} - CMD_GATEWAYINFO - RSA decrypt failed`,
+                    {
+                      error: getError(rsaError),
+                      stationSN: this.rawStation.station_sn,
+                      isECDHDevice: isECDHDevice,
+                      hasEccKey: !!cipher.ecc_private_key,
+                    }
+                  );
+
+                  // Try ECDH only for known ECDH devices (T8214/T8425)
+                  if (isECDHDevice && cipher.ecc_private_key) {
+                    try {
+                      this.encryption = EncryptionType.LEVEL_2;
+                      this.p2pKey = decryptP2PKeyECDH(rawEncryptedKey, cipher.ecc_private_key);
+                      rootP2PLogger.debug(
+                        `Handle DATA ${P2PDataType[message.dataType]} - CMD_GATEWAYINFO - ECDH success - set encryption level 2`,
+                        {
+                          stationSN: this.rawStation.station_sn,
+                          key: this.p2pKey.toString("hex"),
+                          keyLength: this.p2pKey.length,
+                        }
+                      );
+                    } catch (ecdhErr) {
+                      const ecdhError = ensureError(ecdhErr);
+                      rootP2PLogger.debug(
+                        `Handle DATA ${P2PDataType[message.dataType]} - CMD_GATEWAYINFO - ECDH also failed, falling back to Level 1`,
+                        {
+                          error: getError(ecdhError),
+                          stationSN: this.rawStation.station_sn,
+                        }
+                      );
+                      this.encryption = EncryptionType.LEVEL_1;
+                      this.p2pKey = Buffer.from(
+                        getP2PCommandEncryptionKey(this.rawStation.station_sn, this.rawStation.p2p_did)
+                      );
+                    }
+                  } else {
+                    // Non-ECDH device or no ECC key — fall back to Level 1
+                    this.encryption = EncryptionType.LEVEL_1;
+                    this.p2pKey = Buffer.from(
+                      getP2PCommandEncryptionKey(this.rawStation.station_sn, this.rawStation.p2p_did)
+                    );
+                    rootP2PLogger.debug(
+                      `Handle DATA ${P2PDataType[message.dataType]} - CMD_GATEWAYINFO - RSA failed, set encryption level 1`,
+                      { stationSN: this.rawStation.station_sn, key: this.p2pKey.toString("hex") }
+                    );
+                  }
+                }
               } else {
                 this.encryption = EncryptionType.LEVEL_1;
                 this.p2pKey = Buffer.from(

--- a/src/p2p/utils.ts
+++ b/src/p2p/utils.ts
@@ -680,13 +680,79 @@ export const getLockV12Key = (key: string, publicKey: string): string => {
   ]).toString("hex");
 };
 
+/**
+ * Derive P2P session key using ECDH (for devices like T8214/T8425 that use ECC instead of RSA).
+ *
+ * The `encryptedKey` buffer from CMD_GATEWAYINFO likely contains:
+ *   - Device's ECDH public key (either compressed 33 bytes or uncompressed 65 bytes)
+ *   - Possibly followed by encrypted session key data
+ *
+ * The `eccPrivateKey` is the 32-byte hex string from the cipher API response.
+ */
+export const decryptP2PKeyECDH = (encryptedKey: Buffer, eccPrivateKey: string): Buffer => {
+  const ecdh: ECDH = createECDH("prime256v1");
+  ecdh.setPrivateKey(Buffer.from(eccPrivateKey, "hex"));
+
+  // Determine pubkey format and extract the device's public key
+  const firstByte = encryptedKey[0];
+  let devicePubKey: Buffer;
+  let pubKeyLen: number;
+
+  if (firstByte === 0x04) {
+    // Uncompressed public key (65 bytes)
+    pubKeyLen = 65;
+  } else if (firstByte === 0x02 || firstByte === 0x03) {
+    // Compressed public key (33 bytes)
+    pubKeyLen = 33;
+  } else {
+    // Unknown format — try treating first 33 bytes as pubkey
+    pubKeyLen = 33;
+  }
+
+  // Scenario A/B: encryptedKey IS just the device's public key (no ECIES envelope)
+  if (encryptedKey.length <= pubKeyLen + 1) {
+    devicePubKey = encryptedKey.subarray(0, pubKeyLen);
+    const sharedSecret = ecdh.computeSecret(devicePubKey);
+    return sharedSecret.subarray(0, 16);
+  }
+
+  // Scenario C: ECIES envelope — pubkey + iv(16) + ciphertext(48) + hmac(32) = 96 bytes after pubkey
+  devicePubKey = encryptedKey.subarray(0, pubKeyLen);
+  const remainder = encryptedKey.subarray(pubKeyLen);
+
+  const sharedSecret = ecdh.computeSecret(devicePubKey);
+  const derivedKey = eufyKDF(sharedSecret);
+  const aesKey = derivedKey.subarray(0, 16);
+
+  // ECIES standard layout: iv(16) + ciphertext(N*16, typically 48) + hmac(32)
+  // Minimum valid: iv(16) + ciphertext(16) + hmac(32) = 64 bytes
+  if (remainder.length >= 64) {
+    const iv = remainder.subarray(0, 16);
+    const hmacLen = 32;
+    const ciphertext = remainder.subarray(16, remainder.length - hmacLen);
+
+    // Ensure ciphertext length is a multiple of 16 (AES block size)
+    const alignedLen = Math.floor(ciphertext.length / 16) * 16;
+    if (alignedLen > 0) {
+      const alignedCiphertext = ciphertext.subarray(0, alignedLen);
+      const decipher = createDecipheriv("aes-128-cbc", aesKey, iv);
+      decipher.setAutoPadding(false);
+      const decrypted = Buffer.concat([decipher.update(alignedCiphertext), decipher.final()]);
+      // Return first 16 bytes as the P2P session key (AES-128-ECB requires 16-byte key)
+      return decrypted.subarray(0, 16);
+    }
+  }
+
+  // Fallback: if remainder is too small for ECIES, try using raw shared secret
+  return sharedSecret.subarray(0, 16);
+};
+
 let _talkbackSeq = 0;
 let _talkbackTimestamp = 0;
 
 export const resetTalkbackCounters = (): void => {
   _talkbackSeq = 0;
-  _talkbackTimestamp = 0;
-};
+  _talkbackTimestamp = 0;};
 
 export const buildTalkbackAudioFrameHeader = (audioData: Buffer, channel = 0): Buffer => {
   const audioDataLength = Buffer.allocUnsafe(4);

--- a/src/p2p/utils.ts
+++ b/src/p2p/utils.ts
@@ -752,7 +752,8 @@ let _talkbackTimestamp = 0;
 
 export const resetTalkbackCounters = (): void => {
   _talkbackSeq = 0;
-  _talkbackTimestamp = 0;};
+  _talkbackTimestamp = 0;
+};
 
 export const buildTalkbackAudioFrameHeader = (audioData: Buffer, channel = 0): Buffer => {
   const audioDataLength = Buffer.allocUnsafe(4);
@@ -760,7 +761,7 @@ export const buildTalkbackAudioFrameHeader = (audioData: Buffer, channel = 0): B
   const unknown1 = Buffer.alloc(1);
   const audioType = Buffer.alloc(1);
   const audioSeq = Buffer.allocUnsafe(2);
-  audioSeq.writeUInt16LE(_talkbackSeq & 0xFFFF);
+  audioSeq.writeUInt16LE(_talkbackSeq & 0xffff);
   _talkbackSeq++;
   const audioTimestamp = Buffer.alloc(8);
   audioTimestamp.writeBigUInt64LE(BigInt(_talkbackTimestamp));


### PR DESCRIPTION
# Enable ECDH encryption for T8214 and T8425 P2P sessions

## Summary

T8214 (Battery Doorbell Plus E340) and T8425 (Floodlight Camera) use ECDH key exchange instead of RSA for P2P session encryption. This PR adds ECDH support, **gated exclusively to these two devices**.

Depends on #793 (device registration + livestream routing).

## What was wrong

When the station sends `CMD_GATEWAYINFO`, T8214/T8425 provide an ECDH public key instead of RSA-encrypted data. The RSA decrypt fails and the session falls back to Level 1 encryption, breaking livestream.

## What this PR does

1. Adds `ecc_private_key` optional field to the Cipher API model.
2. Adds `decryptP2PKeyECDH` function to derive the session key via ECDH shared secret.
3. In `CMD_GATEWAYINFO` handling: tries RSA first, falls back to ECDH **only if** `station_sn` starts with `T8214` or `T8425` and `ecc_private_key` exists.
4. Adds block-alignment guard — skips decryption when payload is not a multiple of 16 bytes (observed with 36-byte status replies from these devices).
5. Unit tests for `decryptP2PKeyECDH` (6 tests, all passing).

## Testing

- ECDH key exchange tested end-to-end on T8214 and T8425.
- 6 unit tests for `decryptP2PKeyECDH` covering compressed/uncompressed pubkeys, ECIES envelopes, determinism, and output size.
