### PR TITLE
fix: HB3 video download - add startTime/endTime to payload, fix stream handler, increase query limit

### DIFF
--- a/src/eufysecurity.ts
+++ b/src/eufysecurity.ts
@@ -1480,7 +1480,7 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
     }
   }
 
-  public async startStationDownload(deviceSN: string, path: string, cipherID: number): Promise<void> {
+  public async startStationDownload(deviceSN: string, path: string, cipherID: number, startTime?: number, endTime?: number): Promise<void> {
     const device = await this.getDevice(deviceSN);
     const station = await this.getStation(device.getStationSerial());
 
@@ -1490,7 +1490,7 @@ export class EufySecurity extends TypedEmitter<EufySecurityEvents> {
       });
 
     if (!station.isDownloading(device)) {
-      await station.startDownload(device, path, cipherID);
+      await station.startDownload(device, path, cipherID, startTime, endTime);
     } else {
       rootMainLogger.warn(`The station is already downloading a video for the device ${deviceSN}!`);
     }

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -2036,7 +2036,11 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                   msg_state.commandType === CommandType.CMD_DOORBELL_SET_PAYLOAD)
               ) {
                 this.waitForStreamData(P2PDataType.VIDEO, true);
-              } else if (msg_state.commandType === CommandType.CMD_DOWNLOAD_VIDEO) {
+              } else if (
+                msg_state.commandType === CommandType.CMD_DOWNLOAD_VIDEO ||
+                (msg_state.nestedCommandType === CommandType.CMD_DOWNLOAD_VIDEO &&
+                  msg_state.commandType === CommandType.CMD_SET_PAYLOAD)
+              ) {
                 this.waitForStreamData(P2PDataType.BINARY, true);
               } else if (
                 msg_state.commandType === CommandType.CMD_START_TALKBACK ||
@@ -2613,6 +2617,8 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
           if (message.channel !== 255) {
             this.currentMessageState[P2PDataType.BINARY].p2pStreamChannel = message.channel;
           }
+          // Reset stream data timeout — HB3 needs time to prepare the download
+          this.waitForStreamData(P2PDataType.BINARY, true);
           break;
         case CommandType.CMD_WIFI_CONFIG:
           const rssi = data.readInt32LE();


### PR DESCRIPTION
- Add startTime and endTime fields to HB3 download payload (required for video data to stream)
- Fix response handler to recognize nested CMD_DOWNLOAD_VIDEO via CMD_SET_PAYLOAD
- Reset stream timeout on CMD_CONVERT_MP4_OK to prevent premature disconnect
- Increase databaseQueryByDate count to 1500 for HB3 (firmware supports it reliably)