### PR TITLE
fix: mock timezone in getTimezoneGMTString test

### DIFF
--- a/src/http/__test__/utils.test.tsx
+++ b/src/http/__test__/utils.test.tsx
@@ -110,9 +110,21 @@ describe('Utils file', () => {
     });
 
     test("Test getTimezoneGMTString function" , () => {
-        // TODO : mock other timezones
-        let result = getTimezoneGMTString();
-        expect(result).toStrictEqual("GMT+00:00");
+        const dateSpy = jest.spyOn(Date.prototype, "getTimezoneOffset");
+
+        // UTC (offset 0)
+        dateSpy.mockReturnValue(0);
+        expect(getTimezoneGMTString()).toStrictEqual("GMT+00:00");
+
+        // UTC-5 (EST, offset +300)
+        dateSpy.mockReturnValue(300);
+        expect(getTimezoneGMTString()).toStrictEqual("GMT-05:00");
+
+        // UTC+5:30 (IST, offset -330)
+        dateSpy.mockReturnValue(-330);
+        expect(getTimezoneGMTString()).toStrictEqual("GMT+05:30");
+
+        dateSpy.mockRestore();
     });
 
     test("Test getAbsoluteFilePath function" , () => {


### PR DESCRIPTION
## Summary
- The `getTimezoneGMTString` test hardcoded `GMT+00:00`, so it only passed on machines set to UTC
- Mocks `Date.prototype.getTimezoneOffset` to test three timezones: UTC, EST (UTC-5), and IST (UTC+5:30)
- Resolves the existing TODO comment about mocking other timezones

## Test plan
- [x] `npx jest src/http/__test__/utils.test.tsx` passes (80/80 tests)
- [x] Verified on a non-UTC machine (CST/UTC-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)