### PR TITLE
feat: make P2P stream timeouts configurable

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -97,6 +97,7 @@ import {
   P2PCommand,
   RGBColor,
   StreamMetadata,
+  StreamTimeoutOptions,
 } from "../p2p/interfaces";
 import { P2PClientProtocol } from "../p2p/session";
 import {
@@ -7941,6 +7942,10 @@ export class Station extends TypedEmitter<StationEvents> {
   public isLiveStreaming(device: Device): boolean {
     if (device.getStationSerial() !== this.getSerial()) return false;
     return this.p2pSession.isLiveStreaming(device.getChannel());
+  }
+
+  public setStreamTimeouts(options: StreamTimeoutOptions): void {
+    this.p2pSession.setStreamTimeouts(options);
   }
 
   public isDownloading(device: Device): boolean {

--- a/src/p2p/interfaces.ts
+++ b/src/p2p/interfaces.ts
@@ -176,6 +176,16 @@ export interface StreamMetadata {
   audioCodec: AudioCodec;
 }
 
+/** Configurable timeout values for P2P streaming. All values in milliseconds. */
+export interface StreamTimeoutOptions {
+  /** Max time to wait for stream data before auto-stopping. Default: 5000ms. */
+  streamDataWait?: number;
+  /** Time to wait for first audio frame before declaring no audio. Default: 650ms. */
+  audioCodecAnalyze?: number;
+  /** Max time to wait for an expected sequence number. Default: 20000ms. */
+  expectedSeqNoWait?: number;
+}
+
 export interface DeviceSerial {
   [index: number]: {
     sn: string;

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -104,6 +104,7 @@ import {
   P2PQueueMessage,
   P2PCommand,
   P2PVideoMessageState,
+  StreamTimeoutOptions,
   P2PDatabaseResponse,
   P2PDatabaseQueryLatestInfoResponse,
   P2PDatabaseDeleteResponse,
@@ -150,6 +151,12 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
   private readonly ESD_DISCONNECT_TIMEOUT = 30 * 1000;
   private readonly MAX_STREAM_DATA_WAIT = 5 * 1000;
   private readonly RESEND_NOT_ACKNOWLEDGED_COMMAND = 100;
+
+  private streamTimeouts = {
+    streamDataWait: this.MAX_STREAM_DATA_WAIT,
+    audioCodecAnalyze: this.AUDIO_CODEC_ANALYZE_TIMEOUT,
+    expectedSeqNoWait: this.MAX_EXPECTED_SEQNO_WAIT,
+  };
 
   private readonly UDP_RECVBUFFERSIZE_BYTES = 1048576;
   private readonly MAX_PAYLOAD_BYTES = 1028;
@@ -1572,7 +1579,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
             this.currentMessageState[dataType].waitForSeqNoTimeout = setTimeout(() => {
               this.endStream(dataType, true);
               this.currentMessageState[dataType].waitForSeqNoTimeout = undefined;
-            }, this.MAX_EXPECTED_SEQNO_WAIT);
+            }, this.streamTimeouts.expectedSeqNoWait);
 
           if (!this.currentMessageState[dataType].queuedData.get(message.seqNo)) {
             this.currentMessageState[dataType].queuedData.set(message.seqNo, message);
@@ -2193,10 +2200,10 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
     }
     this.currentMessageState[dataType].p2pStreamingTimeout = setTimeout(() => {
       rootP2PLogger.info(
-        `Stopping the station stream for the device ${this.deviceSNs[this.currentMessageState[dataType].p2pStreamChannel]?.sn}, because we haven't received any data for ${this.MAX_STREAM_DATA_WAIT / 1000} seconds`
+        `Stopping the station stream for the device ${this.deviceSNs[this.currentMessageState[dataType].p2pStreamChannel]?.sn}, because we haven't received any data for ${this.streamTimeouts.streamDataWait / 1000} seconds`
       );
       this.endStream(dataType, sendStopCommand);
-    }, this.MAX_STREAM_DATA_WAIT);
+    }, this.streamTimeouts.streamDataWait);
   }
 
   private handleDataBinaryAndVideo(message: P2PDataMessage): void {
@@ -2401,7 +2408,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                 ) {
                   this.emitStreamStartEvent(message.dataType);
                 }
-              }, this.AUDIO_CODEC_ANALYZE_TIMEOUT);
+              }, this.streamTimeouts.audioCodecAnalyze);
             }
           }
           if (this.currentMessageState[message.dataType].p2pStreamNotStarted) {
@@ -4338,6 +4345,10 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
 
   public isLiveStreaming(channel: number): boolean {
     return this.isStreaming(channel, P2PDataType.VIDEO);
+  }
+
+  public setStreamTimeouts(options: StreamTimeoutOptions): void {
+    this.streamTimeouts = { ...this.streamTimeouts, ...options };
   }
 
   private isCurrentlyStreaming(): boolean {


### PR DESCRIPTION
## Summary

All three P2P stream timeouts (data inactivity, audio codec detection, sequence number wait) are hardcoded constants. `eufy-security-client` deps that need different timing — e.g. a plugin coordinating retry delays with the client's data timeout — have no way to tune them.

This adds a `StreamTimeoutOptions` interface and a `setStreamTimeouts()` setter on both `P2PClientProtocol` and `Station`. Original constants remain as defaults; only explicitly overridden values change.

**Changes:**
- New `StreamTimeoutOptions` interface in `p2p/interfaces.ts`
- `P2PClientProtocol.setStreamTimeouts()` replaces the three hardcoded usages with the configurable object
- `Station.setStreamTimeouts()` delegates to the P2P session

**Backward compatible** — all defaults match current behavior. No existing deps are affected.
