### PR TITLE
fix: add missing rtspStreamUrl property to SoloCam E42 metadata

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -7211,6 +7211,7 @@ export const DeviceProperties: Properties = {
     [PropertyName.DeviceRecordingEndClipMotionStops]: DeviceRecordingEndClipMotionStopsProperty,
     [PropertyName.DeviceDualCamWatchViewMode]: DeviceDualCamWatchViewModeS340Property,
     [PropertyName.DeviceRTSPStream]: DeviceRTSPStreamProperty,
+    [PropertyName.DeviceRTSPStreamUrl]: DeviceRTSPStreamUrlProperty,
     [PropertyName.DeviceDetectionStatisticsWorkingDays]: DeviceDetectionStatisticsWorkingDaysProperty,
     [PropertyName.DeviceDetectionStatisticsDetectedEvents]: DeviceDetectionStatisticsDetectedEventsProperty,
     [PropertyName.DeviceDetectionStatisticsRecordedEvents]: DeviceDetectionStatisticsRecordedEventsProperty,


### PR DESCRIPTION
## Summary

- Add missing `DeviceRTSPStreamUrl` property to SoloCam E42 device metadata — the device declares `DeviceRTSPStream` (and hardware supports RTSP) but lacked the URL property, so `setCustomPropertyValue` threw `InvalidPropertyError` when the station returned the RTSP URL via `CMD_NAS_SWITCH`

Ref: homebridge-plugins/homebridge-eufy-security#838
