### PR TITLE
fix: skip CMD_DOORBELL_SET_PAYLOAD for E340 on MiniBase Chime

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -827,6 +827,14 @@ export class Station extends TypedEmitter<StationEvents> {
     return sn.startsWith("T8025");
   }
 
+  public static isStationMiniBaseChime(type: number): boolean {
+    return type === DeviceType.MINIBASE_CHIME;
+  }
+
+  public static isStationMiniBaseChimeBySn(sn: string): boolean {
+    return sn.startsWith("T8023");
+  }
+
   public isStationHomeBase2OrOlder(): boolean {
     return Station.isStationHomeBase2OrOlder(this.rawStation.device_type);
   }
@@ -837,6 +845,10 @@ export class Station extends TypedEmitter<StationEvents> {
 
   public isStationHomeBaseMini(): boolean {
     return Station.isStationHomeBaseMini(this.rawStation.device_type);
+  }
+
+  public isStationMiniBaseChime(): boolean {
+    return Station.isStationMiniBaseChime(this.rawStation.device_type);
   }
 
   /**
@@ -7659,8 +7671,8 @@ export class Station extends TypedEmitter<StationEvents> {
       );
     } else if (
       device.isOutdoorPanAndTiltCamera() ||
-      device.isBatteryDoorbellDualE340() ||
       device.isFloodLightT8425() ||
+      (device.isBatteryDoorbellDualE340() && !this.isStationMiniBaseChime()) ||
       ((device.isIndoorPTCameraE30() || device.isIndoorCameraBase()) && this.isDeviceControlledByHomeBase())
     ) {
       rootHTTPLogger.debug(`Station start livestream - sending command using CMD_DOORBELL_SET_PAYLOAD (1)`, {


### PR DESCRIPTION
## Summary

- The E340 doorbell was unconditionally routed to `CMD_DOORBELL_SET_PAYLOAD` (1700) for livestreaming, but the MiniBase Chime station rejects this command with `ERROR_INVALID_PARAM` (-110)
- When the station is a MiniBase Chime, fall through to the default `CMD_SET_PAYLOAD` (1350) path which works correctly
- Adds `isStationMiniBaseChime()` helper methods (static, by-serial, and instance) for reuse

## Test plan

- [x] E340 behind MiniBase Chime: livestream should use `CMD_SET_PAYLOAD` and succeed
- [x] E340 behind HomeBase 3: livestream should still use `CMD_DOORBELL_SET_PAYLOAD`

---
Resolves homebridge-plugins/homebridge-eufy-security#877