### PR TITLE
fix: use correct motion detection property for SOLO_CAMERA_E30 (T8171)

### DIFF
--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -7831,7 +7831,7 @@ export const DeviceProperties: Properties = {
     [PropertyName.DeviceBattery]: DeviceBatteryProperty,
     [PropertyName.DeviceBatteryTemp]: DeviceBatteryTempProperty,
     [PropertyName.DeviceAutoNightvision]: DeviceAutoNightvisionSoloProperty,
-    [PropertyName.DeviceMotionDetection]: DeviceMotionDetectionProperty,
+    [PropertyName.DeviceMotionDetection]: DeviceMotionDetectionIndoorSoloFloodProperty,
     [PropertyName.DeviceWatermark]: DeviceWatermarkProperty,
     [PropertyName.DeviceMotionDetected]: DeviceMotionDetectedProperty,
     [PropertyName.DevicePersonDetected]: DevicePersonDetectedProperty,


### PR DESCRIPTION
The SOLO_CAMERA_E30 (T8171) was mapped to DeviceMotionDetectionProperty which expects a value type that doesn't match what the device actually reports, causing "Value is undefined: this shouldn't happend" errors on every stream start and motion detection query.

Switching to DeviceMotionDetectionIndoorSoloFloodProperty matches the device's actual capability reporting.
