### PR TITLE
feat: normalize multi-RDB ADTS frames in P2P audio stream

### DIFF
--- a/src/__test__/adts.test.tsx
+++ b/src/__test__/adts.test.tsx
@@ -1,0 +1,252 @@
+import { normalizeAdtsFrames } from "../p2p/adts";
+
+/**
+ * Helper: build a valid single-RDB ADTS frame (protection_absent=1, no CRC).
+ *
+ * @param payloadSize - size of the fake AAC raw data block
+ * @param profile     - AAC object type (0=Main, 1=LC)
+ * @param sampleIndex - sampling_frequency_index (3=48kHz, 4=44.1kHz, 8=16kHz)
+ * @param channels    - channel_configuration (1=mono, 2=stereo)
+ */
+function buildSingleRdbAdts(
+  payloadSize: number,
+  { profile = 1, sampleIndex = 4, channels = 2 }: { profile?: number; sampleIndex?: number; channels?: number } = {}
+): Buffer {
+  const frameLength = 7 + payloadSize;
+  const header = Buffer.alloc(7);
+
+  // Byte 0: sync word high 8 bits = 0xFF
+  header[0] = 0xff;
+  // Byte 1: sync word low 4 = 0xF, ID=0(MPEG-4), layer=0, protection_absent=1
+  header[1] = 0xf1;
+  // Byte 2: profile(2) | sampleIndex(4) | private(1) | channel_high(1)
+  header[2] = ((profile & 0x03) << 6) | ((sampleIndex & 0x0f) << 2) | ((channels >> 2) & 0x01);
+  // Byte 3: channel_low(2) | orig(1) | home(1) | copyright(1) | copystart(1) | frame_length_high(2)
+  header[3] = ((channels & 0x03) << 6) | ((frameLength >> 11) & 0x03);
+  // Byte 4: frame_length_mid(8)
+  header[4] = (frameLength >> 3) & 0xff;
+  // Byte 5: frame_length_low(3) | buffer_fullness_high(5)
+  header[5] = ((frameLength & 0x07) << 5) | 0x1f; // buffer fullness = 0x7FF (VBR)
+  // Byte 6: buffer_fullness_low(6) | num_rdb(2)
+  header[6] = 0xfc; // buffer fullness low 6 bits = all 1, num_rdb = 0
+
+  const payload = Buffer.alloc(payloadSize, 0xaa);
+  return Buffer.concat([header, payload]);
+}
+
+/**
+ * Helper: build a multi-RDB ADTS frame (protection_absent=1, no CRC).
+ * Each RDB payload is filled with a distinct byte for identification.
+ */
+function buildMultiRdbAdts(
+  rdbSizes: number[],
+  { profile = 1, sampleIndex = 4, channels = 2 }: { profile?: number; sampleIndex?: number; channels?: number } = {}
+): Buffer {
+  const numRdb = rdbSizes.length;
+  if (numRdb < 2 || numRdb > 4) throw new Error("numRdb must be 2-4");
+
+  // Position table: (numRdb - 1) entries × 2 bytes each.
+  const posTableSize = (numRdb - 1) * 2;
+  const rdbTotalSize = rdbSizes.reduce((a, b) => a + b, 0);
+  const frameLength = 7 + posTableSize + rdbTotalSize;
+
+  const header = Buffer.alloc(7);
+  header[0] = 0xff;
+  header[1] = 0xf1; // protection_absent=1
+  header[2] = ((profile & 0x03) << 6) | ((sampleIndex & 0x0f) << 2) | ((channels >> 2) & 0x01);
+  header[3] = ((channels & 0x03) << 6) | ((frameLength >> 11) & 0x03);
+  header[4] = (frameLength >> 3) & 0xff;
+  header[5] = ((frameLength & 0x07) << 5) | 0x1f;
+  header[6] = 0xfc | ((numRdb - 1) & 0x03); // num_rdb = numRdb - 1
+
+  // Build position table (byte offsets relative to start of RDB 0).
+  const posTable = Buffer.alloc(posTableSize);
+  let cumulativeOffset = 0;
+  for (let i = 0; i < numRdb - 1; i++) {
+    cumulativeOffset += rdbSizes[i];
+    posTable.writeUInt16BE(cumulativeOffset, i * 2);
+  }
+
+  // Build RDB payloads — each filled with a distinct byte.
+  const rdbBuffers = rdbSizes.map((size, i) => Buffer.alloc(size, 0x10 + i));
+
+  return Buffer.concat([header, posTable, ...rdbBuffers]);
+}
+
+/**
+ * Helper: build a multi-RDB ADTS frame WITH CRC (protection_absent=0).
+ */
+function buildMultiRdbAdtsWithCrc(
+  rdbSizes: number[],
+  { profile = 1, sampleIndex = 4, channels = 2 }: { profile?: number; sampleIndex?: number; channels?: number } = {}
+): Buffer {
+  const numRdb = rdbSizes.length;
+  if (numRdb < 2 || numRdb > 4) throw new Error("numRdb must be 2-4");
+
+  const posTableSize = (numRdb - 1) * 2;
+  const rdbTotalSize = rdbSizes.reduce((a, b) => a + b, 0);
+  const frameLength = 7 + 2 + posTableSize + rdbTotalSize; // +2 for CRC
+
+  const header = Buffer.alloc(7);
+  header[0] = 0xff;
+  header[1] = 0xf0; // protection_absent=0 (CRC present)
+  header[2] = ((profile & 0x03) << 6) | ((sampleIndex & 0x0f) << 2) | ((channels >> 2) & 0x01);
+  header[3] = ((channels & 0x03) << 6) | ((frameLength >> 11) & 0x03);
+  header[4] = (frameLength >> 3) & 0xff;
+  header[5] = ((frameLength & 0x07) << 5) | 0x1f;
+  header[6] = 0xfc | ((numRdb - 1) & 0x03);
+
+  // Fake CRC (2 bytes).
+  const crc = Buffer.alloc(2, 0x00);
+
+  // Position table.
+  const posTable = Buffer.alloc(posTableSize);
+  let cumulativeOffset = 0;
+  for (let i = 0; i < numRdb - 1; i++) {
+    cumulativeOffset += rdbSizes[i];
+    posTable.writeUInt16BE(cumulativeOffset, i * 2);
+  }
+
+  const rdbBuffers = rdbSizes.map((size, i) => Buffer.alloc(size, 0x10 + i));
+
+  return Buffer.concat([header, crc, posTable, ...rdbBuffers]);
+}
+
+describe("normalizeAdtsFrames", () => {
+  describe("non-ADTS data", () => {
+    it("should return non-ADTS data unchanged", () => {
+      const data = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+      const result = normalizeAdtsFrames(data);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(data); // same reference
+    });
+
+    it("should return too-short buffers unchanged", () => {
+      const data = Buffer.from([0xff, 0xf1, 0x50]);
+      const result = normalizeAdtsFrames(data);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(data);
+    });
+  });
+
+  describe("single-RDB frames", () => {
+    it("should return a single-RDB frame as-is (zero-copy)", () => {
+      const frame = buildSingleRdbAdts(100);
+      const result = normalizeAdtsFrames(frame);
+      expect(result).toHaveLength(1);
+      // subarray shares the underlying ArrayBuffer — verify no copy.
+      expect(result[0].buffer).toBe(frame.buffer);
+      expect(result[0].length).toBe(frame.length);
+    });
+
+    it("should handle multiple concatenated single-RDB frames", () => {
+      const frame1 = buildSingleRdbAdts(80);
+      const frame2 = buildSingleRdbAdts(120);
+      const combined = Buffer.concat([frame1, frame2]);
+      const result = normalizeAdtsFrames(combined);
+      expect(result).toHaveLength(2);
+      expect(result[0].length).toBe(frame1.length);
+      expect(result[1].length).toBe(frame2.length);
+    });
+  });
+
+  describe("multi-RDB frames (no CRC)", () => {
+    it("should split a 2-RDB frame into 2 single-RDB frames", () => {
+      const rdbSizes = [64, 80];
+      const multiFrame = buildMultiRdbAdts(rdbSizes);
+      const result = normalizeAdtsFrames(multiFrame);
+      expect(result).toHaveLength(2);
+
+      // Each output frame should be 7 (header) + rdbSize.
+      expect(result[0].length).toBe(7 + 64);
+      expect(result[1].length).toBe(7 + 80);
+
+      // Verify payload content (first RDB filled with 0x10, second with 0x11).
+      expect(result[0][7]).toBe(0x10);
+      expect(result[1][7]).toBe(0x11);
+
+      // Verify each output has num_rdb=0 and protection_absent=1.
+      for (const frame of result) {
+        expect(frame[6] & 0x03).toBe(0); // num_rdb = 0
+        expect(frame[1] & 0x01).toBe(1); // protection_absent = 1
+      }
+    });
+
+    it("should split a 3-RDB frame into 3 single-RDB frames", () => {
+      const rdbSizes = [50, 60, 70];
+      const multiFrame = buildMultiRdbAdts(rdbSizes);
+      const result = normalizeAdtsFrames(multiFrame);
+      expect(result).toHaveLength(3);
+      expect(result[0].length).toBe(7 + 50);
+      expect(result[1].length).toBe(7 + 60);
+      expect(result[2].length).toBe(7 + 70);
+    });
+
+    it("should split a 4-RDB frame into 4 single-RDB frames", () => {
+      const rdbSizes = [30, 40, 50, 60];
+      const multiFrame = buildMultiRdbAdts(rdbSizes);
+      const result = normalizeAdtsFrames(multiFrame);
+      expect(result).toHaveLength(4);
+      for (let i = 0; i < 4; i++) {
+        expect(result[i].length).toBe(7 + rdbSizes[i]);
+        expect(result[i][7]).toBe(0x10 + i);
+      }
+    });
+
+    it("should preserve ADTS header fields in split frames", () => {
+      const multiFrame = buildMultiRdbAdts([100, 100], { profile: 1, sampleIndex: 8, channels: 1 });
+      const result = normalizeAdtsFrames(multiFrame);
+      expect(result).toHaveLength(2);
+      for (const frame of result) {
+        // profile = 1 (LC) → bits 6-7 of byte 2
+        expect((frame[2] >> 6) & 0x03).toBe(1);
+        // sampleIndex = 8 (16kHz) → bits 2-5 of byte 2
+        expect((frame[2] >> 2) & 0x0f).toBe(8);
+      }
+    });
+  });
+
+  describe("multi-RDB frames (with CRC)", () => {
+    it("should split a 2-RDB frame with CRC into 2 single-RDB frames", () => {
+      const rdbSizes = [64, 80];
+      const multiFrame = buildMultiRdbAdtsWithCrc(rdbSizes);
+      const result = normalizeAdtsFrames(multiFrame);
+      expect(result).toHaveLength(2);
+      expect(result[0].length).toBe(7 + 64);
+      expect(result[1].length).toBe(7 + 80);
+      // Output frames should NOT have CRC (protection_absent=1).
+      for (const frame of result) {
+        expect(frame[1] & 0x01).toBe(1);
+      }
+    });
+  });
+
+  describe("mixed concatenated frames", () => {
+    it("should handle a single-RDB frame followed by a multi-RDB frame", () => {
+      const single = buildSingleRdbAdts(90);
+      const multi = buildMultiRdbAdts([50, 60]);
+      const combined = Buffer.concat([single, multi]);
+      const result = normalizeAdtsFrames(combined);
+      expect(result).toHaveLength(3); // 1 + 2
+      expect(result[0].length).toBe(7 + 90);
+      expect(result[1].length).toBe(7 + 50);
+      expect(result[2].length).toBe(7 + 60);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle truncated frame gracefully", () => {
+      const frame = buildSingleRdbAdts(100);
+      const truncated = frame.subarray(0, 50); // cut short
+      const result = normalizeAdtsFrames(truncated);
+      expect(result).toHaveLength(1);
+      expect(result[0].length).toBe(50);
+    });
+
+    it("should handle empty buffer", () => {
+      const result = normalizeAdtsFrames(Buffer.alloc(0));
+      expect(result).toHaveLength(1);
+      expect(result[0].length).toBe(0);
+    });
+  });
+});

--- a/src/p2p/adts.ts
+++ b/src/p2p/adts.ts
@@ -1,0 +1,211 @@
+import { rootP2PLogger } from "../logging";
+
+// ADTS header: 7 bytes (protection_absent=1) or 9 bytes (protection_absent=0).
+// Byte 6 bits 0-1: number_of_raw_data_blocks_in_frame (0 = 1 RDB, 3 = 4 RDBs).
+// Multi-RDB frames pack several AAC raw data blocks into one ADTS frame.
+// Most decoders (including FFmpeg's native aac) only support single-RDB frames,
+// so we split multi-RDB frames into individual single-RDB ADTS frames.
+
+const ADTS_SYNC_WORD = 0xfff;
+const ADTS_MIN_HEADER_SIZE = 7;
+
+/**
+ * Returns true when the first two bytes contain an ADTS sync word (0xFFF).
+ */
+function hasAdtsSyncWord(buf: Buffer, offset: number): boolean {
+  if (offset + 1 >= buf.length) return false;
+  return ((buf[offset] << 4) | (buf[offset + 1] >> 4)) === ADTS_SYNC_WORD;
+}
+
+/**
+ * Extract the 13-bit frame_length field from an ADTS header starting at `offset`.
+ * frame_length includes the header itself.
+ */
+function getFrameLength(buf: Buffer, offset: number): number {
+  return ((buf[offset + 3] & 0x03) << 11) | (buf[offset + 4] << 3) | ((buf[offset + 5] >> 5) & 0x07);
+}
+
+/**
+ * Extract the 2-bit number_of_raw_data_blocks_in_frame field (0-indexed, so actual
+ * count is value + 1).
+ */
+function getNumRawDataBlocks(buf: Buffer, offset: number): number {
+  return buf[offset + 6] & 0x03;
+}
+
+/**
+ * Returns true when `protection_absent` is 0 (CRC present).
+ */
+function hasCrc(buf: Buffer, offset: number): boolean {
+  return (buf[offset + 1] & 0x01) === 0;
+}
+
+/**
+ * Build a single-RDB ADTS frame by prepending a rewritten 7-byte header (without
+ * CRC) to a raw data block.  The template header is cloned from the original
+ * multi-RDB frame and patched:
+ *   - frame_length   → 7 + rdbData.length
+ *   - num_rdb        → 0 (meaning 1 block)
+ *   - protection_absent → 1 (no CRC, since we don't recompute it)
+ */
+function buildSingleRdbFrame(templateHeader: Buffer, headerOffset: number, rdbData: Buffer): Buffer {
+  const newLen = ADTS_MIN_HEADER_SIZE + rdbData.length;
+  const out = Buffer.allocUnsafe(newLen);
+
+  // Copy the 7-byte header template.
+  templateHeader.copy(out, 0, headerOffset, headerOffset + ADTS_MIN_HEADER_SIZE);
+
+  // Set protection_absent = 1 (bit 0 of byte 1).
+  out[1] |= 0x01;
+
+  // Rewrite frame_length (13 bits spanning bytes 3-5).
+  out[3] = (out[3] & 0xfc) | ((newLen >> 11) & 0x03);
+  out[4] = (newLen >> 3) & 0xff;
+  out[5] = ((newLen & 0x07) << 5) | (out[5] & 0x1f);
+
+  // Set number_of_raw_data_blocks_in_frame = 0 (bits 0-1 of byte 6).
+  out[6] &= 0xfc;
+
+  // Append the raw data block.
+  rdbData.copy(out, ADTS_MIN_HEADER_SIZE);
+
+  return out;
+}
+
+/**
+ * Split a single multi-RDB ADTS frame into individual single-RDB frames.
+ *
+ * For multi-RDB frames the spec (ISO 14496-3 §1.A.3) places a
+ * `raw_data_block_position` table after the header (and CRC when present) that
+ * gives the byte offset of each RDB relative to the start of the first RDB.
+ *
+ * Layout:
+ *   [7-byte header]
+ *   [2-byte CRC]            ← only if protection_absent=0
+ *   [2-byte position] × (N) ← N = number_of_raw_data_blocks_in_frame (i.e. num_rdb)
+ *   [RDB 0 data ...]
+ *   [RDB 1 data ...]
+ *   ...
+ *
+ * The position entries give byte offsets relative to the start of RDB 0.
+ * RDB 0 implicitly starts at offset 0.  Position[i] gives the start of RDB i+1.
+ */
+function splitMultiRdbFrame(buf: Buffer, offset: number, frameLength: number): Buffer[] {
+  const numRdbMinusOne = getNumRawDataBlocks(buf, offset); // 1-3
+  const numRdb = numRdbMinusOne + 1;
+  const crcPresent = hasCrc(buf, offset);
+
+  // Calculate where the position table starts.
+  let posTableStart = offset + ADTS_MIN_HEADER_SIZE;
+  if (crcPresent) {
+    posTableStart += 2; // skip CRC-16
+  }
+
+  // We need (numRdb - 1) position entries, each 2 bytes.
+  const posTableSize = (numRdb - 1) * 2;
+  const rdbDataStart = posTableStart + posTableSize;
+
+  if (rdbDataStart > offset + frameLength) {
+    rootP2PLogger.warn("ADTS multi-RDB frame too short for position table", {
+      frameLength,
+      numRdb,
+      rdbDataStart: rdbDataStart - offset,
+    });
+    return [buf.subarray(offset, offset + frameLength)];
+  }
+
+  // Read position table: offsets relative to the start of RDB 0.
+  const rdbOffsets: number[] = [0]; // RDB 0 always starts at relative offset 0
+  for (let i = 0; i < numRdb - 1; i++) {
+    rdbOffsets.push(buf.readUInt16BE(posTableStart + i * 2));
+  }
+
+  const rdbSectionEnd = offset + frameLength;
+  const result: Buffer[] = [];
+
+  for (let i = 0; i < numRdb; i++) {
+    const start = rdbDataStart + rdbOffsets[i];
+    const end = i < numRdb - 1 ? rdbDataStart + rdbOffsets[i + 1] : rdbSectionEnd;
+
+    if (start >= end || end > rdbSectionEnd) {
+      rootP2PLogger.warn("ADTS multi-RDB frame has invalid RDB boundaries", {
+        rdbIndex: i,
+        start: start - offset,
+        end: end - offset,
+        frameLength,
+      });
+      // Return remaining data as a single frame rather than losing it.
+      if (start < rdbSectionEnd) {
+        result.push(buildSingleRdbFrame(buf, offset, buf.subarray(start, rdbSectionEnd)));
+      }
+      break;
+    }
+
+    result.push(buildSingleRdbFrame(buf, offset, buf.subarray(start, end)));
+  }
+
+  return result;
+}
+
+/**
+ * Normalize a buffer of ADTS audio data by scanning for ADTS frames and splitting
+ * any multi-RDB frames into individual single-RDB frames.
+ *
+ * The input buffer may contain one or more concatenated ADTS frames.  Non-ADTS
+ * data (or data without a valid sync word) is returned unchanged in a
+ * single-element array.
+ *
+ * For the common case of a single-RDB frame, no allocation occurs — the original
+ * buffer region is returned via subarray.
+ */
+export function normalizeAdtsFrames(data: Buffer): Buffer[] {
+  if (data.length < ADTS_MIN_HEADER_SIZE || !hasAdtsSyncWord(data, 0)) {
+    // Not ADTS data — return as-is.
+    return [data];
+  }
+
+  const result: Buffer[] = [];
+  let pos = 0;
+
+  while (pos + ADTS_MIN_HEADER_SIZE <= data.length) {
+    if (!hasAdtsSyncWord(data, pos)) {
+      // Lost sync — push remaining bytes and stop.
+      rootP2PLogger.debug("ADTS sync lost, pushing remaining bytes as-is", {
+        offset: pos,
+        remaining: data.length - pos,
+      });
+      result.push(data.subarray(pos));
+      break;
+    }
+
+    const frameLength = getFrameLength(data, pos);
+
+    if (frameLength < ADTS_MIN_HEADER_SIZE || pos + frameLength > data.length) {
+      // Incomplete or invalid frame — push remaining bytes.
+      rootP2PLogger.debug("ADTS frame length invalid or truncated", {
+        offset: pos,
+        frameLength,
+        available: data.length - pos,
+      });
+      result.push(data.subarray(pos));
+      break;
+    }
+
+    const numRdbMinusOne = getNumRawDataBlocks(data, pos);
+
+    if (numRdbMinusOne === 0) {
+      // Single RDB — zero-copy, return subarray of original buffer.
+      result.push(data.subarray(pos, pos + frameLength));
+    } else {
+      // Multi-RDB — split into individual frames.
+      const splitFrames = splitMultiRdbFrame(data, pos, frameLength);
+      for (const frame of splitFrames) {
+        result.push(frame);
+      }
+    }
+
+    pos += frameLength;
+  }
+
+  return result.length > 0 ? result : [data];
+}

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -130,6 +130,7 @@ import { BleCommandFactory, BleParameterIndex } from "./ble";
 import { CommandName, ParamType, Station } from "../http";
 import { getError, parseJSON } from "../utils";
 import { rootP2PLogger } from "../logging";
+import { normalizeAdtsFrames } from "./adts";
 
 export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
   private readonly MAX_RETRIES = 10;
@@ -2505,7 +2506,17 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
             }
           }
 
-          this.currentMessageState[message.dataType].audioStream?.push(audio_data);
+          {
+            const codec = this.currentMessageState[message.dataType].p2pStreamMetadata.audioCodec;
+            const stream = this.currentMessageState[message.dataType].audioStream;
+            if (stream && (codec === AudioCodec.AAC || codec === AudioCodec.AAC_LC)) {
+              for (const frame of normalizeAdtsFrames(audio_data)) {
+                stream.push(frame);
+              }
+            } else {
+              stream?.push(audio_data);
+            }
+          }
           break;
         default:
           rootP2PLogger.debug(`Handle DATA ${P2PDataType[message.dataType]} - Not implemented message`, {


### PR DESCRIPTION
## Summary

- Some cameras (e.g. SoloCam E42) send ADTS frames with multiple Raw Data Blocks. Most decoders only handle single-RDB frames.
- Adds ADTS normalizer in the P2P audio path that splits multi-RDB frames into single-RDB frames before pushing to the stream.
- Only active for AAC/AAC_LC. Zero-copy for single-RDB (common case). Graceful fallback on parse errors.

## Test plan

- [ ] `npm run test` — 12 new ADTS tests pass
- [ ] `npm run build` — builds cleanly
- [ ] Verify audio on SoloCam E42 and other cameras
