### PR TITLE
fix: register LOCK_85V0 (T85V0) in DeviceProperties and DeviceCommands maps

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -2170,7 +2170,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
       Device.isLockWifiR20(type) ||
       Device.isLockWifiVideo(type) ||
       Device.isLockWifiT8506(type) ||
-      Device.isLockWifiT85V0(type, "") ||
+      Device.isLockWifiT85V0(type) ||
       Device.isLockWifiT8502(type) ||
       Device.isLockWifiT85L0(type) ||
       Device.isLockWifiT8531(type) ||
@@ -2261,15 +2261,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
     return false;
   }
 
-  static isLockWifiT85V0(type: number, serialnumber: string): boolean {
-    if (
-      type == DeviceType.LOCK_85V0 &&
-      serialnumber.startsWith("T85V0") &&
-      serialnumber.length > 6 &&
-      serialnumber.charAt(6) === "9"
-    )
-      return true;
-    return false;
+  static isLockWifiT85V0(type: number): boolean {
+    return DeviceType.LOCK_85V0 == type;
   }
 
   static isLockWifiT85L0(type: number): boolean {
@@ -2726,7 +2719,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
   }
 
   public isLockWifiT85V0(): boolean {
-    return Device.isLockWifiT85V0(this.rawDevice.device_type, this.rawDevice.device_sn);
+    return Device.isLockWifiT85V0(this.rawDevice.device_type);
   }
 
   public isLockWifiT85L0(): boolean {

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -642,10 +642,7 @@ export class Station extends TypedEmitter<StationEvents> {
       }
       if (property.name === PropertyName.Model && Device.isLockWifiT8510P(this.getDeviceType(), this.getSerial())) {
         return "T8510P";
-      } else if (
-        property.name === PropertyName.Model &&
-        Device.isLockWifiT85V0(this.getDeviceType())
-      ) {
+      } else if (property.name === PropertyName.Model && Device.isLockWifiT85V0(this.getDeviceType())) {
         return "T85V0";
       } else if (property.type === "number") {
         const numericProperty = property as PropertyMetadataNumeric;

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -321,7 +321,7 @@ export class Station extends TypedEmitter<StationEvents> {
       !Device.isLockWifiT8510P(stationData.device_type, stationData.station_sn) &&
       !Device.isLockWifiT8520P(stationData.device_type, stationData.station_sn) &&
       !Device.isLockWifiT85L0(stationData.device_type) &&
-      !Device.isLockWifiT85V0(stationData.device_type, stationData.station_sn)
+      !Device.isLockWifiT85V0(stationData.device_type)
     ) {
       publicKey = await api.getPublicKey(stationData.station_sn, PublicKeyType.LOCK);
     }
@@ -644,7 +644,7 @@ export class Station extends TypedEmitter<StationEvents> {
         return "T8510P";
       } else if (
         property.name === PropertyName.Model &&
-        Device.isLockWifiT85V0(this.getDeviceType(), this.getSerial())
+        Device.isLockWifiT85V0(this.getDeviceType())
       ) {
         return "T85V0";
       } else if (property.type === "number") {
@@ -17888,7 +17888,7 @@ export class Station extends TypedEmitter<StationEvents> {
       Device.isLockWifiT8502(this.getDeviceType()) ||
       Device.isLockWifiT8510P(this.getDeviceType(), this.getSerial()) ||
       Device.isLockWifiT8520P(this.getDeviceType(), this.getSerial()) ||
-      Device.isLockWifiT85V0(this.getDeviceType(), this.getSerial()) ||
+      Device.isLockWifiT85V0(this.getDeviceType()) ||
       Device.isLockWifiT85L0(this.getDeviceType())
     ) {
       rootHTTPLogger.debug(`Station smart lock send get lock parameters command`, { stationSN: this.getSerial() });
@@ -17923,7 +17923,7 @@ export class Station extends TypedEmitter<StationEvents> {
       Device.isLockWifiT8502(this.getDeviceType()) ||
       Device.isLockWifiT8510P(this.getDeviceType(), this.getSerial()) ||
       Device.isLockWifiT8520P(this.getDeviceType(), this.getSerial()) ||
-      Device.isLockWifiT85V0(this.getDeviceType(), this.getSerial()) ||
+      Device.isLockWifiT85V0(this.getDeviceType()) ||
       Device.isLockWifiT85L0(this.getDeviceType())
     ) {
       rootHTTPLogger.debug(`Station smart lock send get lock status command`, { stationSN: this.getSerial() });

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -5392,12 +5392,12 @@ export const LockT85V0DeviceProperties: IndexedProperty = {
   ...GenericDeviceProperties,
   [PropertyName.DeviceBattery]: DeviceBatteryProperty,
   [PropertyName.DeviceBatteryTemp]: DeviceBatteryTempProperty,
-  [PropertyName.DeviceWifiRSSI]: DeviceWifiRSSIProperty,
+  [PropertyName.DeviceWifiRSSI]: DeviceWifiRSSILockProperty,
   [PropertyName.DeviceWifiSignalLevel]: DeviceWifiSignalLevelProperty,
-  [PropertyName.DeviceEnabled]: DeviceEnabledProperty, //OK
-  [PropertyName.DeviceAutoNightvision]: DeviceAutoNightvisionProperty, //OK
-  [PropertyName.DeviceMotionDetection]: DeviceMotionDetectionProperty, //OK
-  [PropertyName.DeviceWatermark]: DeviceWatermarkBatteryDoorbellCamera1Property, //OK
+  [PropertyName.DeviceEnabled]: DeviceEnabledProperty,
+  [PropertyName.DeviceAutoNightvision]: DeviceAutoNightvisionProperty,
+  [PropertyName.DeviceMotionDetection]: DeviceMotionDetectionProperty,
+  [PropertyName.DeviceWatermark]: DeviceWatermarkBatteryDoorbellCamera1Property,
   [PropertyName.DeviceState]: DeviceStateProperty,
   [PropertyName.DeviceLastChargingDays]: DeviceLastChargingDaysProperty,
   [PropertyName.DeviceLastChargingFalseEvents]: DeviceLastChargingFalseEventsProperty,
@@ -8085,6 +8085,7 @@ export const DeviceProperties: Properties = {
     [PropertyName.DeviceLockEventOrigin]: DeviceLockEventOriginProperty,
     [PropertyName.DevicePersonName]: DevicePersonNameProperty,
   },
+  [DeviceType.LOCK_85V0]: LockT85V0DeviceProperties,
   [DeviceType.LOCK_BLE]: {
     ...GenericDeviceProperties,
     [PropertyName.DeviceState]: DeviceStateLockProperty,
@@ -10610,6 +10611,22 @@ export const DeviceCommands: Commands = {
     CommandName.DeviceUpdateUsername,
   ],
   [DeviceType.LOCK_8530]: [
+    CommandName.DeviceStartLivestream,
+    CommandName.DeviceStopLivestream,
+    CommandName.DeviceQuickResponse,
+    CommandName.DeviceStartDownload,
+    CommandName.DeviceCancelDownload,
+    CommandName.DeviceStartTalkback,
+    CommandName.DeviceStopTalkback,
+    CommandName.DeviceSnooze,
+    CommandName.DeviceLockCalibration,
+    CommandName.DeviceAddUser,
+    CommandName.DeviceDeleteUser,
+    CommandName.DeviceUpdateUserPasscode,
+    CommandName.DeviceUpdateUserSchedule,
+    CommandName.DeviceUpdateUsername,
+  ],
+  [DeviceType.LOCK_85V0]: [
     CommandName.DeviceStartLivestream,
     CommandName.DeviceStopLivestream,
     CommandName.DeviceQuickResponse,

--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -2934,10 +2934,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                         this.rawStation.devices[0]?.device_type,
                         this.rawStation.devices[0]?.device_sn
                       ) ||
-                      Device.isLockWifiT85V0(
-                        this.rawStation.devices[0]?.device_type,
-                        this.rawStation.devices[0]?.device_sn
-                      ) ||
+                      Device.isLockWifiT85V0(this.rawStation.devices[0]?.device_type) ||
                       Device.isLockWifiT8531(this.rawStation.devices[0]?.device_type) ||
                       Device.isLockWifiT85L0(this.rawStation.devices[0]?.device_type)
                     ) {


### PR DESCRIPTION
## Summary

The LOCK_85V0 (FamiLock S3 / T85V0, type 203) was added in #803 but `LockT85V0DeviceProperties` was never registered in the `DeviceProperties` or `DeviceCommands` lookup maps. This caused the device to fall back to `GenericDeviceProperties` with only ~3 basic properties (name, model, serial).

Fixes #853

## Changes

- **Register `LockT85V0DeviceProperties`** in the `DeviceProperties` map so the device gets its full ~90 property set
- **Register `DeviceCommands`** for LOCK_85V0 (mirroring LOCK_8530 — livestream, talkback, lock user management, etc.)
- **Fix `isLockWifiT85V0`** — changed from a serial-gated check (`charAt(6) === "9"`) to a type-only check, consistent with all other dedicated-type locks (T8506, T8502, T85L0, T8531, T85D0). Since LOCK_85V0 has its own `DeviceType` (203), the serial check was unnecessary and prevented valid T85V0 devices from being recognized as locks
- **Fix WiFi RSSI property** — changed from `DeviceWifiRSSIProperty` (commandId 1142) to `DeviceWifiRSSILockProperty` (commandId 1141), consistent with other lock device types
