### PR TITLE
fix(station): route enableDevice for outdoor PT cams through CMD_SET_PAYLOAD

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -7417,6 +7417,31 @@ export class Station extends TypedEmitter<StationEvents> {
           property: propertyData,
         }
       );
+    } else if (device.isOutdoorPanAndTiltCamera()) {
+      // Outdoor pan/tilt cams (eufyCam S4 / T8172 etc.) behind a HomeBase 3
+      // silently drop raw CMD_DEVS_SWITCH frames. Pcap comparison against
+      // the iOS Eufy app shows they accept the same wrapped envelope as
+      // INDOOR_PT_CAMERA_S350 — outer CMD_SET_PAYLOAD carrying inner
+      // CMD_INDOOR_ENABLE_PRIVACY_MODE_S350.
+      param_value = value === true ? 0 : 1;
+      this.p2pSession.sendCommandWithStringPayload(
+        {
+          commandType: CommandType.CMD_SET_PAYLOAD,
+          value: JSON.stringify({
+            account_id: this.rawStation.member.admin_user_id,
+            cmd: CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350,
+            mChannel: device.getChannel(),
+            mValue3: 0,
+            payload: {
+              switch: param_value,
+            },
+          }),
+          channel: device.getChannel(),
+        },
+        {
+          property: propertyData,
+        }
+      );
     } else {
       this.p2pSession.sendCommandWithIntString(
         {

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -5781,6 +5781,7 @@ export const DeviceProperties: Properties = {
   },
   [DeviceType.CAMERA_S4]: {
     ...GenericDeviceProperties,
+    [PropertyName.DeviceEnabled]: DeviceEnabledIndoorS350Property,
     [PropertyName.DeviceWifiRSSI]: DeviceWifiRSSIProperty,
     [PropertyName.DeviceWifiSignalLevel]: DeviceWifiSignalLevelProperty,
     [PropertyName.DeviceBattery]: DeviceBatteryProperty,


### PR DESCRIPTION
## Problem

The eufyCam S4 (T8172) and other outdoor pan/tilt cams behind a HomeBase 3 silently drop raw `CMD_DEVS_SWITCH` frames. Calling `setProperty(device, PropertyName.DeviceEnabled, …)` returns success and the lib's local cache flips, but the cam stays in its previous state and the iOS Eufy app continues to show the old value indefinitely.

## Root cause

The S4 (`OUTDOOR_PT_CAMERA` family) falls into the default branch of `Station.enableDevice()` and emits raw `CMD_DEVS_SWITCH` (1035). HomeBase 3 silently drops that frame for outdoor PT cams.

LAN-side packet capture against the iOS Eufy app shows the same toggle travels as a `CMD_SET_PAYLOAD` (1350) envelope carrying inner `CMD_INDOOR_ENABLE_PRIVACY_MODE_S350` (6250) — the exact same wrapped path the lib already uses for `INDOOR_PT_CAMERA_S350`:

```
iOS app → HB3:   f1d0 00ad d1 00 0004 585a5948 4605 9900 ... [CMD_SET_PAYLOAD]
lib (3.8) → HB3: f1d0 00a4 d1 00 0006 585a5948 0b04 9000 ... [CMD_DEVS_SWITCH, dropped]
```

## Fix

* Add an `isOutdoorPanAndTiltCamera()` branch in `Station.enableDevice()` mirroring the existing `isIndoorPanAndTiltCameraS350()` branch above it.
* Add `[PropertyName.DeviceEnabled]: DeviceEnabledIndoorS350Property` to the `CAMERA_S4` property bag so `setProperty('enabled', …)` is no longer rejected with `NotSupportedError` before reaching the station dispatch.

After the patch the cam reacts immediately and HB3 acks with an 880-byte response (where the raw command got nothing). The companion read-side fix is in #__READ_PR__ — write and read flow through the same wrapped param key.

## Verified on

* HomeBase 3 (T8030), firmware 3.4.3.0
* eufyCam S4 (T8172), firmware 1.0.8.1
* `eufy-security-client` master @ 337dc99

Refs #710.