### PR TITLE
fix: route enableDevice for outdoor PT cams through CMD_SET_PAYLOAD

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -7416,6 +7416,31 @@ export class Station extends TypedEmitter<StationEvents> {
           property: propertyData,
         }
       );
+    } else if (device.isOutdoorPanAndTiltCamera()) {
+      // Outdoor pan/tilt cams (eufyCam S4 / T8172 etc.) behind a HomeBase 3
+      // silently drop raw CMD_DEVS_SWITCH frames. Pcap comparison against
+      // the iOS Eufy app shows they accept the same wrapped envelope as
+      // INDOOR_PT_CAMERA_S350 — outer CMD_SET_PAYLOAD carrying inner
+      // CMD_INDOOR_ENABLE_PRIVACY_MODE_S350.
+      param_value = value === true ? 0 : 1;
+      this.p2pSession.sendCommandWithStringPayload(
+        {
+          commandType: CommandType.CMD_SET_PAYLOAD,
+          value: JSON.stringify({
+            account_id: this.rawStation.member.admin_user_id,
+            cmd: CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350,
+            mChannel: device.getChannel(),
+            mValue3: 0,
+            payload: {
+              switch: param_value,
+            },
+          }),
+          channel: device.getChannel(),
+        },
+        {
+          property: propertyData,
+        }
+      );
     } else {
       this.p2pSession.sendCommandWithIntString(
         {

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -5786,6 +5786,7 @@ export const DeviceProperties: Properties = {
   },
   [DeviceType.CAMERA_S4]: {
     ...GenericDeviceProperties,
+    [PropertyName.DeviceEnabled]: DeviceEnabledIndoorS350Property,
     [PropertyName.DeviceWifiRSSI]: DeviceWifiRSSIProperty,
     [PropertyName.DeviceWifiSignalLevel]: DeviceWifiSignalLevelProperty,
     [PropertyName.DeviceBattery]: DeviceBatteryProperty,


### PR DESCRIPTION
Refs #710.

## Problem

The `eufyCam S4` (`T8172`) and other outdoor pan/tilt cams behind a HomeBase 3 silently drop raw `CMD_DEVS_SWITCH` (1035) frames. Calling

```ts
await eufy.setDeviceProperty(s4.getSerial(), PropertyName.DeviceEnabled, false);
```

returns `success: true` and the lib's local cache flips, but the cam stays in its previous state and the Eufy app continues to show the old value indefinitely. The cam type was added in 3.8.0 but `enableDevice()` falls into the default branch that emits the raw command.

## Root cause

Pcap comparison against the iOS Eufy app on the same cam shows the toggle travels as a wrapped `CMD_SET_PAYLOAD` (1350) envelope carrying inner `CMD_INDOOR_ENABLE_PRIVACY_MODE_S350` (6250) — identical to the path the lib already uses for `INDOOR_PT_CAMERA_S350`:

```
iOS app  → HB3:   f1d0 00ad d1 00 0004 ... [CMD_SET_PAYLOAD]
lib (3.8) → HB3:  f1d0 00a4 d1 00 0006 ... [CMD_DEVS_SWITCH, dropped]
```

After routing the S4 through the wrapped envelope, the cam reacts immediately and HB3 sends an 880-byte ack (where the raw command got no response at all).

## Fix

- Add an `isOutdoorPanAndTiltCamera()` branch in `Station.enableDevice()`, identical in shape to the existing `isIndoorPanAndTiltCameraS350()` branch.
- Add `DeviceEnabled` to the `CAMERA_S4` property bag so `setProperty('enabled', ...)` is accepted before reaching the station dispatch.

## Verified on

- HomeBase 3 (`T8030`), firmware 3.4.3.0
- eufyCam S4 (`T8172`), firmware 1.0.8.1
- iOS Eufy app v6.0.20 reflects the toggle within ~1 s.

## Companion PR

The corresponding read path (lib's `enabled` property never reflects external toggles for these cams) is fixed in a separate small PR — happy to open it once this lands. The bridge-side `station.get_camera_info` re-enable for `eufy-security-ws` is also coming as a separate PR.