### PR TITLE
fix: read enabled state for outdoor PT cams from the wrapped privacy-mode key

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -31,6 +31,7 @@ import {
   DeviceDetectionStatisticsWorkingDaysProperty,
   DeviceDetectionStatisticsDetectedEventsProperty,
   DeviceDetectionStatisticsRecordedEventsProperty,
+  DeviceEnabledIndoorS350Property,
   DeviceEnabledSoloProperty,
   FloodlightT8420XDeviceProperties,
   WiredDoorbellT8200XDeviceProperties,
@@ -354,7 +355,8 @@ export class Device extends TypedEmitter<DeviceEvents> {
       if (
         property.key === ParamType.PRIVATE_MODE ||
         property.key === ParamType.OPEN_DEVICE ||
-        property.key === CommandType.CMD_DEVS_SWITCH
+        property.key === CommandType.CMD_DEVS_SWITCH ||
+        property.key === CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350
       ) {
         if (
           (this.isIndoorCamera() && !this.isIndoorPanAndTiltCameraS350()) ||
@@ -1800,7 +1802,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
       if (!this.isSmartDrop()) {
         //TODO: Check with future devices if this property overriding is correct (for example with indoor cameras etc.)
-        newMetadata[PropertyName.DeviceEnabled] = DeviceEnabledSoloProperty;
+        // Outdoor pan/tilt cams (eufyCam S4 etc.) report enabled state
+        // through the wrapped CMD_INDOOR_ENABLE_PRIVACY_MODE_S350 (6250)
+        // param. Binding them to DeviceEnabledSoloProperty (key=1035) here
+        // would re-anchor the read on a value the cam never updates again.
+        if (this.isOutdoorPanAndTiltCamera()) {
+          newMetadata[PropertyName.DeviceEnabled] = DeviceEnabledIndoorS350Property;
+        } else {
+          newMetadata[PropertyName.DeviceEnabled] = DeviceEnabledSoloProperty;
+        }
       }
 
       metadata = newMetadata;

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -1363,7 +1363,12 @@ export const DeviceEnabledIndoorMiniProperty: PropertyMetadataBoolean = {
 
 export const DeviceEnabledIndoorS350Property: PropertyMetadataBoolean = {
   ...DeviceEnabledSoloProperty,
-  key: CommandType.CMD_DEVS_SWITCH,
+  // The HomeBase 3 keeps the live cam-enabled state under the wrapped
+  // CMD_INDOOR_ENABLE_PRIVACY_MODE_S350 (6250) param. The legacy
+  // CMD_DEVS_SWITCH (1035) only ever reflects raw bridge-side writes
+  // and goes stale forever for cams that exclusively use the wrapped
+  // path (S350, outdoor PT cams etc.).
+  key: CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350,
   commandId: CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350,
 };
 


### PR DESCRIPTION
Refs #710. Builds on #873 (the write-path fix); both PRs together close the loop on `enabled` for outdoor PT cams.

## Problem

After fixing the `enableDevice()` write path, the master `enabled` toggle for `CAMERA_S4` etc. correctly propagates from the lib to the cam. The reverse direction is still broken: when the iOS Eufy app toggles the same cam, the lib never updates its `enabled` property — `device.getPropertyValue('enabled')` keeps returning whatever the lib last wrote (or its boot snapshot if the lib never wrote).

## Root cause

Three compounding issues, all on the read side:

1. `DeviceEnabledIndoorS350Property.key` is `CMD_DEVS_SWITCH` (1035). The HomeBase 3 keeps the live cam-enabled state under `param_type = CMD_INDOOR_ENABLE_PRIVACY_MODE_S350` (6250). I confirmed this with a probe in `_handleCameraInfoParameters`: HB3 reports `channel=0 type=6250 value=\"1\"` for an S4 the user just turned off in the iOS app, while still reporting `channel=0 type=1035 value=\"0\"` from the older bridge-write — the legacy key is the bridge-side write echo, frozen forever for cams that never get a raw `CMD_DEVS_SWITCH`.

2. `Device.getPropertiesMetadata()` has a late HB3-mode override at the bottom that unconditionally re-binds `DeviceEnabled` to `DeviceEnabledSoloProperty` (key=1035) for any HB3-controlled cam carrying motion-detection types — including S4 / `OUTDOOR_PT_CAMERA`. That undoes the rekey from (1).

3. `Device.convertRawPropertyValue()` recognises only an explicit set of keys for the boolean enabled-style mapping (`0 → true`, `1 → false`). Once the property's key is `CMD_INDOOR_ENABLE_PRIVACY_MODE_S350`, that switch needs to include 6250 too, otherwise the conversion falls through to default and stores the raw `\"0\"`/`\"1\"` string.

## Fix

Three coordinated patches:

```ts
// types.ts
export const DeviceEnabledIndoorS350Property = {
    ...DeviceEnabledSoloProperty,
    key: CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350,
    commandId: CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350,
};
```

```ts
// device.ts — convertRawPropertyValue
if (
    property.key === ParamType.PRIVATE_MODE ||
    property.key === ParamType.OPEN_DEVICE ||
    property.key === CommandType.CMD_DEVS_SWITCH ||
    property.key === CommandType.CMD_INDOOR_ENABLE_PRIVACY_MODE_S350
) { /* boolean conversion */ }
```

```ts
// device.ts — getPropertiesMetadata, HB3 motion-types override block
if (!this.isSmartDrop()) {
    if (this.isOutdoorPanAndTiltCamera()) {
        newMetadata[PropertyName.DeviceEnabled] = DeviceEnabledIndoorS350Property;
    } else {
        newMetadata[PropertyName.DeviceEnabled] = DeviceEnabledSoloProperty;
    }
}
```

For full external-toggle visibility a consumer also needs to call `station.getCameraInfo()` periodically and let the cam-info-params dispatch refresh `enabled`. That is a separate concern in `eufy-security-ws` — separate PR coming.

## Verified on

- HomeBase 3 (`T8030`), firmware 3.4.3.0
- eufyCam S4 (`T8172`), firmware 1.0.8.1
- iOS Eufy app v6.0.20: toggle in/out of the App matches `device.getPropertyValue('enabled')` after a fresh `getCameraInfo()` round-trip.