### PR TITLE
Restore CMD_STORAGE_INFO_HB3 notify handler removed by #847 merge

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -3604,6 +3604,15 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
                 if (payload) {
                   this.emit("garage door status", message.channel, payload.door_id, payload.type);
                 }
+              } else if (json.cmd === CommandType.CMD_STORAGE_INFO_HB3) {
+                const payload = json.payload as StorageInfoHB3;
+                rootP2PLogger.debug(
+                  `Handle DATA ${P2PDataType[message.dataType]} - CMD_NOTIFY_PAYLOAD StorageInfo HB3 update`,
+                  { stationSN: this.rawStation.station_sn, body: payload?.body }
+                );
+                if (payload) {
+                  this.emit("storage info hb3", message.channel, payload.body);
+                }
               } else if (json.cmd === 6246) {
                 const payload = json.payload as { num?: number };
                 rootP2PLogger.debug(


### PR DESCRIPTION
Closes #877.

### Problem

[PR #847](https://github.com/bropat/eufy-security-client/pull/847) (E30 P2P livestream support) merged commit [`09f2f5b`](https://github.com/bropat/eufy-security-client/commit/09f2f5b2ab6907f40adb18c6a4c513edd4054918) (*Fix merge conflict with develop and clean livestream status handler*) which, alongside the intended livestream-status cleanup, also dropped the `CMD_STORAGE_INFO_HB3` branch from the `CMD_NOTIFY_PAYLOAD` dispatch in `src/p2p/session.ts`.

The `StorageInfoHB3` type import (line 22) and the `models.ts` definition stayed in place — only the actual notify handler was removed. `master` is unaffected and still has the handler.

### Effect

HomeBase 3 / HomeBase Mini consumers that depend on `station.storageInfoEmmc` get a permanent "data unavailable" state on builds tracking `develop`:

1. `EufySecurity.onStationConnect` → `refreshP2PData` → `Station.getStorageInfoEx` sends `CMD_SET_PAYLOAD` with inner `cmd: CMD_STORAGE_INFO_HB3`.
2. The HB3 replies with `CMD_NOTIFY_PAYLOAD` carrying `json.cmd === 1307 (CMD_STORAGE_INFO_HB3)` and `json.payload.body.emmc_info` populated.
3. Without this branch, the dispatch falls into the `// CMD_NOTIFY_PAYLOAD - Not implemented 2` debug branch.
4. `"storage info hb3"` is never emitted → `EufySecurity.onStorageInfoHb3` never runs → `station.properties.storageInfoEmmc` stays unset.

### Fix

Re-adds the verbatim handler from `master` next to the existing `garage door status` / `hub notify update` branches, restoring the pre-#847 behaviour.

```ts
} else if (json.cmd === CommandType.CMD_STORAGE_INFO_HB3) {
    const payload = json.payload as StorageInfoHB3;
    rootP2PLogger.debug(
        `Handle DATA ${P2PDataType[message.dataType]} - CMD_NOTIFY_PAYLOAD StorageInfo HB3 update`,
        { stationSN: this.rawStation.station_sn, body: payload?.body }
    );
    if (payload) {
        this.emit("storage info hb3", message.channel, payload.body);
    }
}
```

### Verified

- Hardware: HomeBase 3 (`T8030`), firmware 3.x.
- Bridge: `eufy-security-ws` schema 21.
- With patch applied, `station.get_properties` for the HB3 returns `storageInfoEmmc` populated with `disk_size`, `system_size`, `disk_used`, `data_used_percent`, `swap_size`, `video_size`, `video_used`, `data_partition_size`, `eol_percent`, `work_status`, `health`.
- `npm run build` clean (TypeScript compiles, no new lint warnings).