### PR TITLE
handle v2 from push notification

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,4 +4,5 @@
   - [Features](features.md)
   - [Supported devices](supported_devices.md)
   - [Reporting unknown devices](reporting_unknown_devices.md)
+  - [v2 image format](v2_image_format.md)
   - [License](license.md)

--- a/docs/v2_image_format.md
+++ b/docs/v2_image_format.md
@@ -1,0 +1,84 @@
+# eufy `v2_eufysecurity:` image format — and how to decode it without a key
+
+Reverse-engineered for eufy app v6 (HomeBase 3 / unified eufy Security app).
+**TL;DR: it is NOT encrypted in any meaningful sense — only the JPEG *header* is
+scrambled. Discard it, splice on a fresh standard header, and the image renders.
+No key, no E2E, no cipher.**
+
+## Where the blob comes from
+
+There are **two separate image paths** — only the HTTP one produces a `v2_` blob:
+
+| Path | Source | What you get | Decode needed? |
+|---|---|---|---|
+| **HTTP** | GET the push `pic_url` | `v2_eufysecurity:…` (header-scrambled) | yes (this doc) |
+| **P2P** | station `image download` event | plain JPEG, full-res | no — already an image |
+
+`pic_url` itself is just a plain HTTPS URL; **the `v2_` blob is the HTTP response body** when you fetch it:
+
+```
+push message ──► pic_url = https://security-app-<REGION>.eufylife.com/v1/s/g/<TOKEN>
+                     │  HTTP GET
+                     ▼
+   response body = v2_eufysecurity:<STATION_SERIAL>:<10-DIGIT-PKT>:<binary payload>
+```
+
+> Note: the P2P path returns clean JPEGs at **different** dimensions than the v2 blob for the same
+> camera — so you can't use P2P sizes to decode v2.
+
+## Wire format
+
+```
+v2_eufysecurity : <STATION_SERIAL> : <10-DIGIT-PKT> : <binary payload>
+└──── magic ────┘ └── e.g. T8… ───┘ └─ packet id ─┘ └── the image ──┘
+```
+
+Split on the **first 3 colons only** — the 4th field is raw binary and may itself contain `0x3A` (`:`).
+
+## The binary payload — head-only scramble
+
+```
+            ┌──────── ENCRYPTED (~286 bytes) ────────┐┌──────────── PLAINTEXT JPEG ────────────┐
+ byte 0                                            ~286                                       end
+   │                                                  │                                          │
+   ▼                                                  ▼                                          ▼
+   ┌──────────────────────────────────────────────────┬──────────────────────────────────────────┐
+   │  AES-GCM-scrambled JPEG header:                   │  normal, untouched JPEG:                   │
+   │    • SOI                                          │    • rest of DHT (Huffman tables)          │
+   │    • APP0 / JFIF                                  │    • SOS  (start of scan)                  │
+   │    • DQT  (quantization tables)                   │    • ░░░ entropy-coded pixel data ░░░       │
+   │    • SOF  ◄── image WIDTH & HEIGHT (now lost)     │       ...the whole picture...              │
+   │    • start of DHT                                 │    • EOI  (FF D9)                           │
+   └──────────────────────────────────────────────────┴──────────────────────────────────────────┘
+                                                      ▲
+                            splice point: the standard baseline marker
+                            FF C4 00 1F 01  (DC-chrominance Huffman table)
+                            = first readable byte; everything after is plain JPEG (~95%+ of the file)
+```
+
+The scramble is AES-256-GCM (AAD `"eufy security"`) — but you never need to break it, because the only
+useful things it hides are the quantization tables (a tiny quality/colour difference if you substitute
+standard ones) and the **image dimensions**.
+
+## Decode (no key)
+
+```
+1. payload    = response body after the 3rd ':'
+2. tail       = payload[ payload.indexOf(FF C4 00 1F 01) : ]      # the plaintext JPEG
+3. header     = a freshly built standard baseline JPEG header (SOI+APP0+DQT+SOF[W×H]+DHT)
+4. image      = header ++ tail                                     # a valid JPEG → renders
+```
+
+The only unknowns are **W, H, and chroma subsampling**, because the SOF was in the scrambled head.
+eufy uses **non-standard sizes** (e.g. 288×176, 552×408, 1272×728), so recover them from the pixels:
+
+- **Width** = the value that minimises mean row-to-row difference. A wrong width shears the image (the
+  picture "runs diagonally down"); the correct width makes rows line up. Sweep candidate widths and take
+  the minimum.
+- **Height** = grow the frame until the decoder hits the embedded EOI and errors ("unexpected `FF D9`");
+  the largest height that still decodes is the true height.
+- **Subsampling** ∈ {4:2:0, 4:2:2, 4:4:4} — pick the one with the least colour speckle (wrong subsampling
+  gives saturated green/magenta blocks). Most images are 4:2:0; some snapshots are 4:4:4.
+
+> Caveat: the EXIF orientation tag was also in the scrambled head, so some reconstructed images (e.g. from
+> doorbells) come out rotated 90°. The pixels are correct; only the display-orientation hint is lost.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "got": "^14.4.2",
         "i18n-iso-countries": "^7.12.0",
         "image-type": "^6.1.0",
+        "jpeg-js": "0.4.4",
         "long": "^5.2.3",
         "mqtt": "^5.15.0",
         "node-rsa": "^1.1.1",
@@ -46,6 +47,9 @@
       },
       "engines": {
         "node": ">=24.0.0"
+      },
+      "optionalDependencies": {
+        "jpeg-js": "^0.4.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4639,6 +4643,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/js-sdsl": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -85,5 +85,8 @@
   "bugs": {
     "url": "https://github.com/bropat/eufy-security-client/issues"
   },
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "optionalDependencies": {
+    "jpeg-js": "^0.4.4"
+  }
 }

--- a/src/http/decodeImageV2.ts
+++ b/src/http/decodeImageV2.ts
@@ -1,0 +1,349 @@
+/**
+ * Keyless decoder for eufy `v2_eufysecurity:` event / thumbnail images.
+ *
+ * The v2 wire format is NOT end-to-end encrypted and needs NO key, cipher, or
+ * E2E private key. It is *head-only obfuscation*: only a fixed ~286-byte JPEG
+ * prefix is AES-GCM encrypted (SOI + APP0/JFIF + the two DQT quantization
+ * tables + SOF dimensions + the first DHT table). Everything from the standard
+ * baseline DC-chrominance Huffman table marker (`FF C4 00 1F 01`) onward — the
+ * rest of the DHT, the SOS, the entire entropy-coded scan and the EOI — is left
+ * as plaintext, standard baseline JPEG.
+ *
+ * So we reconstruct a viewable JPEG by splicing a freshly built *standard*
+ * libjpeg header (correct width/height + chroma subsampling) onto the blob's
+ * plaintext tail. The encrypted prefix only ever held the quantization tables
+ * (=> a small quality/colour shift if we substitute standard q85 tables) and
+ * the image dimensions (=> the only thing that must be pinned exactly).
+ *
+ * Wire format:  v2_eufysecurity:<SERIAL>:<10-digit-pkt>:<binary-ciphertext>
+ *
+ * Reverse-engineered 2026-06-04. Verified on 136 live blobs across every camera
+ * model / resolution under HomeBase 3 (dominant 256x144 4:2:0 = event thumbnail).
+ */
+
+/** Standard baseline-JPEG DC-chrominance DHT marker — the first plaintext byte
+ *  run in a v2 blob, and the splice point. */
+const DC_CHROMA = Buffer.from([0xff, 0xc4, 0x00, 0x1f, 0x01]);
+
+export const V2_PREFIX = "v2_eufysecurity:";
+
+/**
+ * Canonical standard libjpeg header (quality 85, 4:2:0), covering
+ * SOI + APP0 + DQT(luma) + DQT(chroma) + SOF0 + DHT(DC-luma) + DHT(AC-luma).
+ * It stops right before its own DC-chroma DHT, because the blob tail supplies
+ * the DC-chroma + AC-chroma DHT, the SOS and the scan. Dimensions are a
+ * placeholder (0x0101 x 0x0101) and the chroma sampling factor is patched at
+ * runtime (see splice offsets below).
+ */
+const PREFIX_TEMPLATE = Buffer.from(
+    "ffd8ffe000104a46494600010100000100010000ffdb0043000503040404030504040405050506070c08070707070f0b0b090c110f1212110f111113161c1713141a1511111821181a1d1d1f1f1f13172224221e241c1e1f1effdb0043010505050706070e08080e1e1411141e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1effc00011080101010103012200021101031101ffc4001f0000010501010101010100000000000000000102030405060708090a0bffc400b5100002010303020403050504040000017d01020300041105122131410613516107227114328191a1082342b1c11552d1f02433627282090a161718191a25262728292a3435363738393a434445464748494a535455565758595a636465666768696a737475767778797a838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1f2f3f4f5f6f7f8f9fa",
+    "hex",
+);
+// Byte offsets into PREFIX_TEMPLATE that we patch per image.
+const OFF_HEIGHT = 163; // SOF0 height, big-endian uint16
+const OFF_WIDTH = 165; //  SOF0 width,  big-endian uint16
+const OFF_Y_SAMPLING = 169; // luma component sampling factor (0x22=4:2:0, 0x21=4:2:2, 0x11=4:4:4)
+
+export type ChromaSubsampling = "4:2:0" | "4:2:2" | "4:4:4";
+const Y_SAMPLING: Record<ChromaSubsampling, number> = { "4:2:0": 0x22, "4:2:2": 0x21, "4:4:4": 0x11 };
+
+/** Build the standard JPEG header for a given geometry by patching the template. */
+export function buildJpegPrefix(width: number, height: number, subsampling: ChromaSubsampling = "4:2:0"): Buffer {
+    const p = Buffer.from(PREFIX_TEMPLATE); // copy
+    p.writeUInt16BE(height & 0xffff, OFF_HEIGHT);
+    p.writeUInt16BE(width & 0xffff, OFF_WIDTH);
+    p[OFF_Y_SAMPLING] = Y_SAMPLING[subsampling];
+    return p;
+}
+
+/** Extract the binary ciphertext from a `v2_eufysecurity:SN:PKT:<binary>` blob. */
+function v2Ciphertext(data: Buffer): Buffer | null {
+    if (data.subarray(0, V2_PREFIX.length).toString("latin1") !== V2_PREFIX) return null;
+    // Split on the first three colons only — the 4th field is raw binary that may contain 0x3a.
+    let colon = 0;
+    let idx = 0;
+    for (let i = 0; i < data.length && colon < 3; i++) {
+        if (data[i] === 0x3a) {
+            colon++;
+            idx = i + 1;
+        }
+    }
+    return colon === 3 ? data.subarray(idx) : null;
+}
+
+/**
+ * Reconstruct a viewable JPEG from a v2 blob at a *known* geometry.
+ * Returns null if the input is not a v2 blob or has no plaintext tail.
+ */
+export function spliceV2Image(
+    data: Buffer,
+    width: number,
+    height: number,
+    subsampling: ChromaSubsampling = "4:2:0",
+): Buffer | null {
+    const ct = v2Ciphertext(data) ?? (data.indexOf(DC_CHROMA) >= 0 ? data : null);
+    if (!ct) return null;
+    const cut = ct.indexOf(DC_CHROMA);
+    if (cut < 0) return null;
+    return Buffer.concat([buildJpegPrefix(width, height, subsampling), ct.subarray(cut)]);
+}
+
+/** 16:9 then 4:3 size ladder, small→large, used for geometry auto-detection. */
+const SIZE_LADDER: Array<[number, number]> = [
+    [160, 90], [240, 135], [256, 144], [320, 180], [384, 216], [400, 225], [480, 270],
+    [512, 288], [576, 324], [640, 360], [704, 396], [768, 432], [848, 480], [960, 540],
+    [1024, 576], [1280, 720], [1600, 900], [1920, 1080], [2560, 1440],
+    [176, 144], [320, 240], [352, 288], [480, 360], [640, 480], [800, 600], [1024, 768], [1280, 960],
+];
+const SUBSAMPLINGS: ChromaSubsampling[] = ["4:2:0", "4:4:4", "4:2:2"];
+
+/**
+ * Decode a v2 blob WITHOUT knowing its dimensions, by brute-forcing the size
+ * ladder and using `jpeg-js` (an optional, pure-JS, dynamically-imported
+ * dependency) to find the geometry where the entropy-coded scan exactly fills
+ * the frame (no premature-EOI fill) with the correct chroma subsampling.
+ *
+ * The fastest production path is to pass the dimensions from event metadata to
+ * {@link spliceV2Image} directly and skip this brute-force entirely.
+ *
+ * @returns the reconstructed JPEG + detected geometry, or null if undetectable
+ *          / `jpeg-js` is not installed.
+ */
+export async function decodeV2ImageAuto(data: Buffer): Promise<{
+    jpeg: Buffer;
+    width: number;
+    height: number;
+    subsampling: ChromaSubsampling;
+    /** true when even the best geometry still looks like colour garbage (atypical/corrupt blob). */
+    lowConfidence: boolean;
+} | null> {
+    let jpegDecode: (d: Buffer | Uint8Array, opts?: unknown) => { width: number; height: number; data: Uint8Array };
+    try {
+        // Indirect the specifier so TS/bundlers treat jpeg-js as a truly optional
+        // runtime dependency (no static module-resolution / type requirement).
+        const specifier = "jpeg-js";
+        const mod: any = await import(specifier);
+        jpegDecode = (mod.decode ?? mod.default?.decode).bind(mod);
+    } catch {
+        return null; // jpeg-js not available — caller should pass explicit dimensions
+    }
+
+    const ct = v2Ciphertext(data) ?? (data.indexOf(DC_CHROMA) >= 0 ? data : null);
+    if (!ct) return null;
+    const cut = ct.indexOf(DC_CHROMA);
+    if (cut < 0) return null;
+    const tail = ct.subarray(cut);
+
+    let best:
+        | { jpeg: Buffer; width: number; height: number; subsampling: ChromaSubsampling; spread: number }
+        | null = null;
+    for (const subsampling of SUBSAMPLINGS) {
+        let filled: { jpeg: Buffer; width: number; height: number; img: DecodedImage } | null = null;
+        for (const [w, h] of SIZE_LADDER) {
+            const jpeg = Buffer.concat([buildJpegPrefix(w, h, subsampling), tail]);
+            let img: DecodedImage;
+            try {
+                img = jpegDecode(jpeg, { maxResolutionInMP: 100, maxMemoryUsageInMB: 512, tolerantDecoding: true });
+            } catch {
+                continue;
+            }
+            // "Filled" = the bottom 3% of rows carry real variation (not the grey
+            //  0x80 premature-EOI fill). The LARGEST fully-filled frame is the
+            //  correct geometry for this subsampling (a smaller frame also fills,
+            //  just ignoring trailing scan data — so keep the max-area candidate,
+            //  not merely the last one seen).
+            if (rowsAreFilled(img) && (!filled || w * h > filled.width * filled.height)) {
+                filled = { jpeg, width: w, height: h, img };
+            }
+        }
+        if (!filled) continue;
+        // A wrong chroma-subsampling guess misreads the chroma planes and produces
+        // saturated colour speckle, so the natural decode is the one with the
+        // lowest mean colour-spread |R-G|+|G-B|+|B-R|. (Outdoor scenes are nearly
+        // grey/brown ⇒ low spread; garbage ⇒ high.)
+        const spread = colorSpread(filled.img);
+        if (!best || spread < best.spread) {
+            best = { jpeg: filled.jpeg, width: filled.width, height: filled.height, subsampling, spread };
+        }
+    }
+    if (!best) return null;
+
+    // The SIZE_LADDER only holds standard resolutions, but eufy images often use
+    // NON-standard dimensions — so the ladder lands on the nearest standard size and
+    // is wrong in two ways that need different fixes:
+    //
+    //  • WIDTH (large snapshots, e.g. 1272 vs 1280): an off-by-a-few-pixels width
+    //    shears every row. We find the true width by minimising row-to-row difference
+    //    (shear raises it). This metric is reliable for large/smooth images but too
+    //    noisy for small detailed thumbnails, so width-refinement is gated to >384px.
+    //
+    //  • HEIGHT (any size, e.g. 256×192 snapped to 256×144): the ladder height can be
+    //    SHORTER than the real image, cutting off the bottom (the ladder frame still
+    //    "fills" because its last row is mid-image). We always re-pin the height to
+    //    where the scan actually ends — this is safe for everything (a true 256×144
+    //    thumbnail's scan ends at 144, so it stays 144).
+    {
+        const ss = best.subsampling;
+        const [mcw, mch] = MCU_SIZE[ss];
+        const decodeAt = (w: number, h: number) => {
+            try {
+                return jpegDecode(Buffer.concat([buildJpegPrefix(w, h, ss), tail]), {
+                    maxResolutionInMP: 400,
+                    maxMemoryUsageInMB: 1024,
+                    tolerantDecoding: true,
+                });
+            } catch {
+                return null;
+            }
+        };
+
+        // --- width refinement (all images) ---
+        // eufy uses NON-standard widths (288, 552, 1272…) that aren't on the ladder,
+        // so the ladder lands on the nearest standard width (256, 576, 1280) and the
+        // error shears the image ("the content runs diagonally down"). The true width
+        // minimises row-to-row difference. The ladder can be off by ~12% (256 vs the
+        // true 288), so search a generous ±25% band around it. The per-image vdiff
+        // MINIMUM is reliable even for small detailed thumbnails (absolute vdiff is
+        // not comparable across images, but the minimum within one image's sweep is).
+        const area = best.width * best.height;
+        let width = best.width;
+        let bestV = Infinity;
+        const lo = Math.max(mcw * 4, Math.round((best.width * 0.75) / mcw) * mcw);
+        const hi = Math.round((best.width * 1.25) / mcw) * mcw;
+        for (let w = lo; w <= hi; w += mcw) {
+            const h = Math.min(2000, Math.max(mch * 2, Math.round(area / w / mch) * mch));
+            const img = decodeAt(w, h);
+            if (!img) continue;
+            const fh = contentBottomRow(img);
+            if (fh < mch * 2) continue;
+            const v = verticalRowDiff(img, fh);
+            if (v < bestV) {
+                bestV = v;
+                width = w;
+            }
+        }
+
+        // --- height refinement (always) ---
+        // At the correct width, a frame TALLER than the real image hits the embedded
+        // EOI and the decode throws ("unexpected ffd9"); a frame ≤ the real height
+        // decodes fine. So the true height is the largest non-throwing height —
+        // binary-search it. (Some images instead pad the extra rows without throwing;
+        // for those the search hits the cap and we trim to the content bottom below.)
+        const HCAP = Math.ceil(2000 / mch);
+        let loH = 1;
+        let hiH = HCAP;
+        let maxHm = 1;
+        while (loH <= hiH) {
+            const mid = (loH + hiH) >> 1;
+            if (decodeAt(width, mid * mch)) {
+                maxHm = mid;
+                loH = mid + 1;
+            } else {
+                hiH = mid - 1;
+            }
+        }
+        let height = maxHm * mch;
+        if (maxHm >= HCAP) {
+            // Decoder padded instead of throwing — trim to the real content bottom.
+            const fin = decodeAt(width, height);
+            if (fin) {
+                const fh = contentBottomRow(fin);
+                if (fh > mch) height = Math.ceil((fh + 1) / mch) * mch;
+            }
+        }
+
+        if (width !== best.width || height !== best.height) {
+            best = {
+                jpeg: Buffer.concat([buildJpegPrefix(width, height, ss), tail]),
+                width,
+                height,
+                subsampling: ss,
+                spread: best.spread,
+            };
+        }
+    }
+
+    // A high colour-spread even on the best candidate means none of the geometries
+    // produced a clean image (atypical/low-light/corrupt blob) — surface that so
+    // callers can choose to skip rather than show garbage.
+    const lowConfidence = best.spread > 70;
+    return {
+        jpeg: best.jpeg,
+        width: best.width,
+        height: best.height,
+        subsampling: best.subsampling,
+        lowConfidence,
+    };
+}
+
+/** Luma MCU block dimensions per chroma-subsampling mode (used for width/height refinement). */
+const MCU_SIZE: Record<ChromaSubsampling, [number, number]> = {
+    "4:2:0": [16, 16],
+    "4:2:2": [16, 8],
+    "4:4:4": [8, 8],
+};
+
+/** Index of the lowest row that still carries real content (not the grey ~0x80
+ *  premature-EOI fill). Used to pin the true image height. */
+function contentBottomRow(img: DecodedImage): number {
+    const { width, height, data } = img;
+    for (let y = height - 1; y >= 0; y--) {
+        let cnt = 0;
+        for (let x = 0; x < width; x++) if (Math.abs(data[(y * width + x) * 4] - 128) > 6) cnt++;
+        if (cnt > width * 0.04) return y;
+    }
+    return -1;
+}
+
+/** Mean vertical (row-to-row) luma difference over the filled region. A correct
+ *  width keeps rows aligned (low); a wrong width shears each row (high). */
+function verticalRowDiff(img: DecodedImage, fh: number): number {
+    const { width, data } = img;
+    let sum = 0;
+    let n = 0;
+    for (let y = 0; y < fh - 1; y++) {
+        for (let x = 0; x < width; x += 2) {
+            sum += Math.abs(data[(y * width + x) * 4] - data[((y + 1) * width + x) * 4]);
+            n++;
+        }
+    }
+    return n ? sum / n : 1e9;
+}
+
+type DecodedImage = { width: number; height: number; data: Uint8Array };
+
+function rowsAreFilled(img: DecodedImage): boolean {
+    const { width, height, data } = img; // RGBA
+    if (height < 4) return false;
+    const startRow = Math.floor(height * 0.97);
+    let nonFill = 0;
+    let samples = 0;
+    for (let y = startRow; y < height; y++) {
+        let min = 255;
+        let max = 0;
+        for (let x = 0; x < width; x++) {
+            const v = data[(y * width + x) * 4]; // R channel
+            if (v < min) min = v;
+            if (v > max) max = v;
+            samples++;
+        }
+        if (max - min > 8) nonFill++;
+    }
+    return samples > 0 && nonFill > 0;
+}
+
+/** Mean per-pixel colour spread |R-G|+|G-B|+|B-R|. Natural (near-grey) scenes are
+ *  low; a wrong chroma-subsampling guess yields saturated speckle and a high value. */
+function colorSpread(img: DecodedImage): number {
+    const { width, height, data } = img;
+    const total = width * height || 1;
+    let sum = 0;
+    for (let p = 0; p < total; p += 2) {
+        const i = p * 4;
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        sum += Math.abs(r - g) + Math.abs(g - b) + Math.abs(b - r);
+    }
+    return sum / Math.ceil(total / 2);
+}

--- a/src/http/decodeImageV2.ts
+++ b/src/http/decodeImageV2.ts
@@ -36,8 +36,8 @@ export const V2_PREFIX = "v2_eufysecurity:";
  * runtime (see splice offsets below).
  */
 const PREFIX_TEMPLATE = Buffer.from(
-    "ffd8ffe000104a46494600010100000100010000ffdb0043000503040404030504040405050506070c08070707070f0b0b090c110f1212110f111113161c1713141a1511111821181a1d1d1f1f1f13172224221e241c1e1f1effdb0043010505050706070e08080e1e1411141e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1effc00011080101010103012200021101031101ffc4001f0000010501010101010100000000000000000102030405060708090a0bffc400b5100002010303020403050504040000017d01020300041105122131410613516107227114328191a1082342b1c11552d1f02433627282090a161718191a25262728292a3435363738393a434445464748494a535455565758595a636465666768696a737475767778797a838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1f2f3f4f5f6f7f8f9fa",
-    "hex",
+  "ffd8ffe000104a46494600010100000100010000ffdb0043000503040404030504040405050506070c08070707070f0b0b090c110f1212110f111113161c1713141a1511111821181a1d1d1f1f1f13172224221e241c1e1f1effdb0043010505050706070e08080e1e1411141e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1effc00011080101010103012200021101031101ffc4001f0000010501010101010100000000000000000102030405060708090a0bffc400b5100002010303020403050504040000017d01020300041105122131410613516107227114328191a1082342b1c11552d1f02433627282090a161718191a25262728292a3435363738393a434445464748494a535455565758595a636465666768696a737475767778797a838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1f2f3f4f5f6f7f8f9fa",
+  "hex"
 );
 // Byte offsets into PREFIX_TEMPLATE that we patch per image.
 const OFF_HEIGHT = 163; // SOF0 height, big-endian uint16
@@ -49,26 +49,26 @@ const Y_SAMPLING: Record<ChromaSubsampling, number> = { "4:2:0": 0x22, "4:2:2": 
 
 /** Build the standard JPEG header for a given geometry by patching the template. */
 export function buildJpegPrefix(width: number, height: number, subsampling: ChromaSubsampling = "4:2:0"): Buffer {
-    const p = Buffer.from(PREFIX_TEMPLATE); // copy
-    p.writeUInt16BE(height & 0xffff, OFF_HEIGHT);
-    p.writeUInt16BE(width & 0xffff, OFF_WIDTH);
-    p[OFF_Y_SAMPLING] = Y_SAMPLING[subsampling];
-    return p;
+  const p = Buffer.from(PREFIX_TEMPLATE); // copy
+  p.writeUInt16BE(height & 0xffff, OFF_HEIGHT);
+  p.writeUInt16BE(width & 0xffff, OFF_WIDTH);
+  p[OFF_Y_SAMPLING] = Y_SAMPLING[subsampling];
+  return p;
 }
 
 /** Extract the binary ciphertext from a `v2_eufysecurity:SN:PKT:<binary>` blob. */
 function v2Ciphertext(data: Buffer): Buffer | null {
-    if (data.subarray(0, V2_PREFIX.length).toString("latin1") !== V2_PREFIX) return null;
-    // Split on the first three colons only — the 4th field is raw binary that may contain 0x3a.
-    let colon = 0;
-    let idx = 0;
-    for (let i = 0; i < data.length && colon < 3; i++) {
-        if (data[i] === 0x3a) {
-            colon++;
-            idx = i + 1;
-        }
+  if (data.subarray(0, V2_PREFIX.length).toString("latin1") !== V2_PREFIX) return null;
+  // Split on the first three colons only — the 4th field is raw binary that may contain 0x3a.
+  let colon = 0;
+  let idx = 0;
+  for (let i = 0; i < data.length && colon < 3; i++) {
+    if (data[i] === 0x3a) {
+      colon++;
+      idx = i + 1;
     }
-    return colon === 3 ? data.subarray(idx) : null;
+  }
+  return colon === 3 ? data.subarray(idx) : null;
 }
 
 /**
@@ -76,24 +76,47 @@ function v2Ciphertext(data: Buffer): Buffer | null {
  * Returns null if the input is not a v2 blob or has no plaintext tail.
  */
 export function spliceV2Image(
-    data: Buffer,
-    width: number,
-    height: number,
-    subsampling: ChromaSubsampling = "4:2:0",
+  data: Buffer,
+  width: number,
+  height: number,
+  subsampling: ChromaSubsampling = "4:2:0"
 ): Buffer | null {
-    const ct = v2Ciphertext(data) ?? (data.indexOf(DC_CHROMA) >= 0 ? data : null);
-    if (!ct) return null;
-    const cut = ct.indexOf(DC_CHROMA);
-    if (cut < 0) return null;
-    return Buffer.concat([buildJpegPrefix(width, height, subsampling), ct.subarray(cut)]);
+  const ct = v2Ciphertext(data) ?? (data.indexOf(DC_CHROMA) >= 0 ? data : null);
+  if (!ct) return null;
+  const cut = ct.indexOf(DC_CHROMA);
+  if (cut < 0) return null;
+  return Buffer.concat([buildJpegPrefix(width, height, subsampling), ct.subarray(cut)]);
 }
 
 /** 16:9 then 4:3 size ladder, small→large, used for geometry auto-detection. */
 const SIZE_LADDER: Array<[number, number]> = [
-    [160, 90], [240, 135], [256, 144], [320, 180], [384, 216], [400, 225], [480, 270],
-    [512, 288], [576, 324], [640, 360], [704, 396], [768, 432], [848, 480], [960, 540],
-    [1024, 576], [1280, 720], [1600, 900], [1920, 1080], [2560, 1440],
-    [176, 144], [320, 240], [352, 288], [480, 360], [640, 480], [800, 600], [1024, 768], [1280, 960],
+  [160, 90],
+  [240, 135],
+  [256, 144],
+  [320, 180],
+  [384, 216],
+  [400, 225],
+  [480, 270],
+  [512, 288],
+  [576, 324],
+  [640, 360],
+  [704, 396],
+  [768, 432],
+  [848, 480],
+  [960, 540],
+  [1024, 576],
+  [1280, 720],
+  [1600, 900],
+  [1920, 1080],
+  [2560, 1440],
+  [176, 144],
+  [320, 240],
+  [352, 288],
+  [480, 360],
+  [640, 480],
+  [800, 600],
+  [1024, 768],
+  [1280, 960],
 ];
 const SUBSAMPLINGS: ChromaSubsampling[] = ["4:2:0", "4:4:4", "4:2:2"];
 
@@ -110,240 +133,239 @@ const SUBSAMPLINGS: ChromaSubsampling[] = ["4:2:0", "4:4:4", "4:2:2"];
  *          / `jpeg-js` is not installed.
  */
 export async function decodeV2ImageAuto(data: Buffer): Promise<{
-    jpeg: Buffer;
-    width: number;
-    height: number;
-    subsampling: ChromaSubsampling;
-    /** true when even the best geometry still looks like colour garbage (atypical/corrupt blob). */
-    lowConfidence: boolean;
+  jpeg: Buffer;
+  width: number;
+  height: number;
+  subsampling: ChromaSubsampling;
+  /** true when even the best geometry still looks like colour garbage (atypical/corrupt blob). */
+  lowConfidence: boolean;
 } | null> {
-    let jpegDecode: (d: Buffer | Uint8Array, opts?: unknown) => { width: number; height: number; data: Uint8Array };
-    try {
-        // Indirect the specifier so TS/bundlers treat jpeg-js as a truly optional
-        // runtime dependency (no static module-resolution / type requirement).
-        const specifier = "jpeg-js";
-        const mod: any = await import(specifier);
-        jpegDecode = (mod.decode ?? mod.default?.decode).bind(mod);
-    } catch {
-        return null; // jpeg-js not available — caller should pass explicit dimensions
+  let jpegDecode: (d: Buffer | Uint8Array, opts?: unknown) => { width: number; height: number; data: Uint8Array };
+  try {
+    // Indirect the specifier so TS/bundlers treat jpeg-js as a truly optional
+    // runtime dependency (no static module-resolution / type requirement).
+    const specifier = "jpeg-js";
+    const mod: any = await import(specifier);
+    jpegDecode = (mod.decode ?? mod.default?.decode).bind(mod);
+  } catch {
+    return null; // jpeg-js not available — caller should pass explicit dimensions
+  }
+
+  const ct = v2Ciphertext(data) ?? (data.indexOf(DC_CHROMA) >= 0 ? data : null);
+  if (!ct) return null;
+  const cut = ct.indexOf(DC_CHROMA);
+  if (cut < 0) return null;
+  const tail = ct.subarray(cut);
+
+  let best: { jpeg: Buffer; width: number; height: number; subsampling: ChromaSubsampling; spread: number } | null =
+    null;
+  for (const subsampling of SUBSAMPLINGS) {
+    let filled: { jpeg: Buffer; width: number; height: number; img: DecodedImage } | null = null;
+    for (const [w, h] of SIZE_LADDER) {
+      const jpeg = Buffer.concat([buildJpegPrefix(w, h, subsampling), tail]);
+      let img: DecodedImage;
+      try {
+        img = jpegDecode(jpeg, { maxResolutionInMP: 100, maxMemoryUsageInMB: 512, tolerantDecoding: true });
+      } catch {
+        continue;
+      }
+      // "Filled" = the bottom 3% of rows carry real variation (not the grey
+      //  0x80 premature-EOI fill). The LARGEST fully-filled frame is the
+      //  correct geometry for this subsampling (a smaller frame also fills,
+      //  just ignoring trailing scan data — so keep the max-area candidate,
+      //  not merely the last one seen).
+      if (rowsAreFilled(img) && (!filled || w * h > filled.width * filled.height)) {
+        filled = { jpeg, width: w, height: h, img };
+      }
     }
-
-    const ct = v2Ciphertext(data) ?? (data.indexOf(DC_CHROMA) >= 0 ? data : null);
-    if (!ct) return null;
-    const cut = ct.indexOf(DC_CHROMA);
-    if (cut < 0) return null;
-    const tail = ct.subarray(cut);
-
-    let best:
-        | { jpeg: Buffer; width: number; height: number; subsampling: ChromaSubsampling; spread: number }
-        | null = null;
-    for (const subsampling of SUBSAMPLINGS) {
-        let filled: { jpeg: Buffer; width: number; height: number; img: DecodedImage } | null = null;
-        for (const [w, h] of SIZE_LADDER) {
-            const jpeg = Buffer.concat([buildJpegPrefix(w, h, subsampling), tail]);
-            let img: DecodedImage;
-            try {
-                img = jpegDecode(jpeg, { maxResolutionInMP: 100, maxMemoryUsageInMB: 512, tolerantDecoding: true });
-            } catch {
-                continue;
-            }
-            // "Filled" = the bottom 3% of rows carry real variation (not the grey
-            //  0x80 premature-EOI fill). The LARGEST fully-filled frame is the
-            //  correct geometry for this subsampling (a smaller frame also fills,
-            //  just ignoring trailing scan data — so keep the max-area candidate,
-            //  not merely the last one seen).
-            if (rowsAreFilled(img) && (!filled || w * h > filled.width * filled.height)) {
-                filled = { jpeg, width: w, height: h, img };
-            }
-        }
-        if (!filled) continue;
-        // A wrong chroma-subsampling guess misreads the chroma planes and produces
-        // saturated colour speckle, so the natural decode is the one with the
-        // lowest mean colour-spread |R-G|+|G-B|+|B-R|. (Outdoor scenes are nearly
-        // grey/brown ⇒ low spread; garbage ⇒ high.)
-        const spread = colorSpread(filled.img);
-        if (!best || spread < best.spread) {
-            best = { jpeg: filled.jpeg, width: filled.width, height: filled.height, subsampling, spread };
-        }
+    if (!filled) continue;
+    // A wrong chroma-subsampling guess misreads the chroma planes and produces
+    // saturated colour speckle, so the natural decode is the one with the
+    // lowest mean colour-spread |R-G|+|G-B|+|B-R|. (Outdoor scenes are nearly
+    // grey/brown ⇒ low spread; garbage ⇒ high.)
+    const spread = colorSpread(filled.img);
+    if (!best || spread < best.spread) {
+      best = { jpeg: filled.jpeg, width: filled.width, height: filled.height, subsampling, spread };
     }
-    if (!best) return null;
+  }
+  if (!best) return null;
 
-    // The SIZE_LADDER only holds standard resolutions, but eufy images often use
-    // NON-standard dimensions — so the ladder lands on the nearest standard size and
-    // is wrong in two ways that need different fixes:
-    //
-    //  • WIDTH (large snapshots, e.g. 1272 vs 1280): an off-by-a-few-pixels width
-    //    shears every row. We find the true width by minimising row-to-row difference
-    //    (shear raises it). This metric is reliable for large/smooth images but too
-    //    noisy for small detailed thumbnails, so width-refinement is gated to >384px.
-    //
-    //  • HEIGHT (any size, e.g. 256×192 snapped to 256×144): the ladder height can be
-    //    SHORTER than the real image, cutting off the bottom (the ladder frame still
-    //    "fills" because its last row is mid-image). We always re-pin the height to
-    //    where the scan actually ends — this is safe for everything (a true 256×144
-    //    thumbnail's scan ends at 144, so it stays 144).
-    {
-        const ss = best.subsampling;
-        const [mcw, mch] = MCU_SIZE[ss];
-        const decodeAt = (w: number, h: number) => {
-            try {
-                return jpegDecode(Buffer.concat([buildJpegPrefix(w, h, ss), tail]), {
-                    maxResolutionInMP: 400,
-                    maxMemoryUsageInMB: 1024,
-                    tolerantDecoding: true,
-                });
-            } catch {
-                return null;
-            }
-        };
-
-        // --- width refinement (all images) ---
-        // eufy uses NON-standard widths (288, 552, 1272…) that aren't on the ladder,
-        // so the ladder lands on the nearest standard width (256, 576, 1280) and the
-        // error shears the image ("the content runs diagonally down"). The true width
-        // minimises row-to-row difference. The ladder can be off by ~12% (256 vs the
-        // true 288), so search a generous ±25% band around it. The per-image vdiff
-        // MINIMUM is reliable even for small detailed thumbnails (absolute vdiff is
-        // not comparable across images, but the minimum within one image's sweep is).
-        const area = best.width * best.height;
-        let width = best.width;
-        let bestV = Infinity;
-        const lo = Math.max(mcw * 4, Math.round((best.width * 0.75) / mcw) * mcw);
-        const hi = Math.round((best.width * 1.25) / mcw) * mcw;
-        for (let w = lo; w <= hi; w += mcw) {
-            const h = Math.min(2000, Math.max(mch * 2, Math.round(area / w / mch) * mch));
-            const img = decodeAt(w, h);
-            if (!img) continue;
-            const fh = contentBottomRow(img);
-            if (fh < mch * 2) continue;
-            const v = verticalRowDiff(img, fh);
-            if (v < bestV) {
-                bestV = v;
-                width = w;
-            }
-        }
-
-        // --- height refinement (always) ---
-        // At the correct width, a frame TALLER than the real image hits the embedded
-        // EOI and the decode throws ("unexpected ffd9"); a frame ≤ the real height
-        // decodes fine. So the true height is the largest non-throwing height —
-        // binary-search it. (Some images instead pad the extra rows without throwing;
-        // for those the search hits the cap and we trim to the content bottom below.)
-        const HCAP = Math.ceil(2000 / mch);
-        let loH = 1;
-        let hiH = HCAP;
-        let maxHm = 1;
-        while (loH <= hiH) {
-            const mid = (loH + hiH) >> 1;
-            if (decodeAt(width, mid * mch)) {
-                maxHm = mid;
-                loH = mid + 1;
-            } else {
-                hiH = mid - 1;
-            }
-        }
-        let height = maxHm * mch;
-        if (maxHm >= HCAP) {
-            // Decoder padded instead of throwing — trim to the real content bottom.
-            const fin = decodeAt(width, height);
-            if (fin) {
-                const fh = contentBottomRow(fin);
-                if (fh > mch) height = Math.ceil((fh + 1) / mch) * mch;
-            }
-        }
-
-        if (width !== best.width || height !== best.height) {
-            best = {
-                jpeg: Buffer.concat([buildJpegPrefix(width, height, ss), tail]),
-                width,
-                height,
-                subsampling: ss,
-                spread: best.spread,
-            };
-        }
-    }
-
-    // A high colour-spread even on the best candidate means none of the geometries
-    // produced a clean image (atypical/low-light/corrupt blob) — surface that so
-    // callers can choose to skip rather than show garbage.
-    const lowConfidence = best.spread > 70;
-    return {
-        jpeg: best.jpeg,
-        width: best.width,
-        height: best.height,
-        subsampling: best.subsampling,
-        lowConfidence,
+  // The SIZE_LADDER only holds standard resolutions, but eufy images often use
+  // NON-standard dimensions — so the ladder lands on the nearest standard size and
+  // is wrong in two ways that need different fixes:
+  //
+  //  • WIDTH (large snapshots, e.g. 1272 vs 1280): an off-by-a-few-pixels width
+  //    shears every row. We find the true width by minimising row-to-row difference
+  //    (shear raises it). This metric is reliable for large/smooth images but too
+  //    noisy for small detailed thumbnails, so width-refinement is gated to >384px.
+  //
+  //  • HEIGHT (any size, e.g. 256×192 snapped to 256×144): the ladder height can be
+  //    SHORTER than the real image, cutting off the bottom (the ladder frame still
+  //    "fills" because its last row is mid-image). We always re-pin the height to
+  //    where the scan actually ends — this is safe for everything (a true 256×144
+  //    thumbnail's scan ends at 144, so it stays 144).
+  {
+    const ss = best.subsampling;
+    const [mcw, mch] = MCU_SIZE[ss];
+    const decodeAt = (w: number, h: number) => {
+      try {
+        return jpegDecode(Buffer.concat([buildJpegPrefix(w, h, ss), tail]), {
+          maxResolutionInMP: 400,
+          maxMemoryUsageInMB: 1024,
+          tolerantDecoding: true,
+        });
+      } catch {
+        return null;
+      }
     };
+
+    // --- width refinement (all images) ---
+    // eufy uses NON-standard widths (288, 552, 1272…) that aren't on the ladder,
+    // so the ladder lands on the nearest standard width (256, 576, 1280) and the
+    // error shears the image ("the content runs diagonally down"). The true width
+    // minimises row-to-row difference. The ladder can be off by ~12% (256 vs the
+    // true 288), so search a generous ±25% band around it. The per-image vdiff
+    // MINIMUM is reliable even for small detailed thumbnails (absolute vdiff is
+    // not comparable across images, but the minimum within one image's sweep is).
+    const area = best.width * best.height;
+    let width = best.width;
+    let bestV = Infinity;
+    const lo = Math.max(mcw * 4, Math.round((best.width * 0.75) / mcw) * mcw);
+    const hi = Math.round((best.width * 1.25) / mcw) * mcw;
+    for (let w = lo; w <= hi; w += mcw) {
+      const h = Math.min(2000, Math.max(mch * 2, Math.round(area / w / mch) * mch));
+      const img = decodeAt(w, h);
+      if (!img) continue;
+      const fh = contentBottomRow(img);
+      if (fh < mch * 2) continue;
+      const v = verticalRowDiff(img, fh);
+      if (v < bestV) {
+        bestV = v;
+        width = w;
+      }
+    }
+
+    // --- height refinement (always) ---
+    // At the correct width, a frame TALLER than the real image hits the embedded
+    // EOI and the decode throws ("unexpected ffd9"); a frame ≤ the real height
+    // decodes fine. So the true height is the largest non-throwing height —
+    // binary-search it. (Some images instead pad the extra rows without throwing;
+    // for those the search hits the cap and we trim to the content bottom below.)
+    const HCAP = Math.ceil(2000 / mch);
+    let loH = 1;
+    let hiH = HCAP;
+    let maxHm = 1;
+    while (loH <= hiH) {
+      const mid = (loH + hiH) >> 1;
+      if (decodeAt(width, mid * mch)) {
+        maxHm = mid;
+        loH = mid + 1;
+      } else {
+        hiH = mid - 1;
+      }
+    }
+    let height = maxHm * mch;
+    if (maxHm >= HCAP) {
+      // Decoder padded instead of throwing — trim to the real content bottom.
+      const fin = decodeAt(width, height);
+      if (fin) {
+        const fh = contentBottomRow(fin);
+        if (fh > mch) height = Math.ceil((fh + 1) / mch) * mch;
+      }
+    }
+
+    if (width !== best.width || height !== best.height) {
+      best = {
+        jpeg: Buffer.concat([buildJpegPrefix(width, height, ss), tail]),
+        width,
+        height,
+        subsampling: ss,
+        spread: best.spread,
+      };
+    }
+  }
+
+  // A high colour-spread even on the best candidate means none of the geometries
+  // produced a clean image (atypical/low-light/corrupt blob) — surface that so
+  // callers can choose to skip rather than show garbage.
+  const lowConfidence = best.spread > 70;
+  return {
+    jpeg: best.jpeg,
+    width: best.width,
+    height: best.height,
+    subsampling: best.subsampling,
+    lowConfidence,
+  };
 }
 
 /** Luma MCU block dimensions per chroma-subsampling mode (used for width/height refinement). */
 const MCU_SIZE: Record<ChromaSubsampling, [number, number]> = {
-    "4:2:0": [16, 16],
-    "4:2:2": [16, 8],
-    "4:4:4": [8, 8],
+  "4:2:0": [16, 16],
+  "4:2:2": [16, 8],
+  "4:4:4": [8, 8],
 };
 
 /** Index of the lowest row that still carries real content (not the grey ~0x80
  *  premature-EOI fill). Used to pin the true image height. */
 function contentBottomRow(img: DecodedImage): number {
-    const { width, height, data } = img;
-    for (let y = height - 1; y >= 0; y--) {
-        let cnt = 0;
-        for (let x = 0; x < width; x++) if (Math.abs(data[(y * width + x) * 4] - 128) > 6) cnt++;
-        if (cnt > width * 0.04) return y;
-    }
-    return -1;
+  const { width, height, data } = img;
+  for (let y = height - 1; y >= 0; y--) {
+    let cnt = 0;
+    for (let x = 0; x < width; x++) if (Math.abs(data[(y * width + x) * 4] - 128) > 6) cnt++;
+    if (cnt > width * 0.04) return y;
+  }
+  return -1;
 }
 
 /** Mean vertical (row-to-row) luma difference over the filled region. A correct
  *  width keeps rows aligned (low); a wrong width shears each row (high). */
 function verticalRowDiff(img: DecodedImage, fh: number): number {
-    const { width, data } = img;
-    let sum = 0;
-    let n = 0;
-    for (let y = 0; y < fh - 1; y++) {
-        for (let x = 0; x < width; x += 2) {
-            sum += Math.abs(data[(y * width + x) * 4] - data[((y + 1) * width + x) * 4]);
-            n++;
-        }
+  const { width, data } = img;
+  let sum = 0;
+  let n = 0;
+  for (let y = 0; y < fh - 1; y++) {
+    for (let x = 0; x < width; x += 2) {
+      sum += Math.abs(data[(y * width + x) * 4] - data[((y + 1) * width + x) * 4]);
+      n++;
     }
-    return n ? sum / n : 1e9;
+  }
+  return n ? sum / n : 1e9;
 }
 
 type DecodedImage = { width: number; height: number; data: Uint8Array };
 
 function rowsAreFilled(img: DecodedImage): boolean {
-    const { width, height, data } = img; // RGBA
-    if (height < 4) return false;
-    const startRow = Math.floor(height * 0.97);
-    let nonFill = 0;
-    let samples = 0;
-    for (let y = startRow; y < height; y++) {
-        let min = 255;
-        let max = 0;
-        for (let x = 0; x < width; x++) {
-            const v = data[(y * width + x) * 4]; // R channel
-            if (v < min) min = v;
-            if (v > max) max = v;
-            samples++;
-        }
-        if (max - min > 8) nonFill++;
+  const { width, height, data } = img; // RGBA
+  if (height < 4) return false;
+  const startRow = Math.floor(height * 0.97);
+  let nonFill = 0;
+  let samples = 0;
+  for (let y = startRow; y < height; y++) {
+    let min = 255;
+    let max = 0;
+    for (let x = 0; x < width; x++) {
+      const v = data[(y * width + x) * 4]; // R channel
+      if (v < min) min = v;
+      if (v > max) max = v;
+      samples++;
     }
-    return samples > 0 && nonFill > 0;
+    if (max - min > 8) nonFill++;
+  }
+  return samples > 0 && nonFill > 0;
 }
 
 /** Mean per-pixel colour spread |R-G|+|G-B|+|B-R|. Natural (near-grey) scenes are
  *  low; a wrong chroma-subsampling guess yields saturated speckle and a high value. */
 function colorSpread(img: DecodedImage): number {
-    const { width, height, data } = img;
-    const total = width * height || 1;
-    let sum = 0;
-    for (let p = 0; p < total; p += 2) {
-        const i = p * 4;
-        const r = data[i];
-        const g = data[i + 1];
-        const b = data[i + 2];
-        sum += Math.abs(r - g) + Math.abs(g - b) + Math.abs(b - r);
-    }
-    return sum / Math.ceil(total / 2);
+  const { width, height, data } = img;
+  const total = width * height || 1;
+  let sum = 0;
+  for (let p = 0; p < total; p += 2) {
+    const i = p * 4;
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    sum += Math.abs(r - g) + Math.abs(g - b) + Math.abs(b - r);
+  }
+  return sum / Math.ceil(total / 2);
 }

--- a/src/http/utils.ts
+++ b/src/http/utils.ts
@@ -30,6 +30,7 @@ import {
   EufyCamC35DetectionTypes,
 } from "./types";
 import { HTTPApi } from "./api";
+import { spliceV2Image, V2_PREFIX } from "./decodeImageV2";
 import { ensureError } from "../error";
 import { ImageBaseCodeError } from "./error";
 import { LockPushEvent } from "./../push/types";
@@ -702,6 +703,24 @@ export const getImageKey = function (serialNumber: string, p2pDid: string, code:
 
 export const decodeImage = function (p2pDid: string, data: Buffer): Buffer {
   if (data.length >= 12) {
+    // v6 "v2_eufysecurity:" thumbnails: head-only obfuscation, decodable WITHOUT
+    // any key (see decodeImageV2.ts). The encrypted JPEG header only hid the
+    // quantization tables + dimensions; the scan data is plaintext standard JPEG.
+    //
+    // NOTE / LIMITATION: this synchronous path reconstructs with a FIXED geometry of
+    // 288x176 4:2:0 — the standard event-thumbnail size, which covers the common
+    // push-notification image. Images of OTHER sizes (e.g. 552x408, 1272x728, 4:4:4
+    // snapshots) will be SHEARED here, because the true dimensions can only be
+    // recovered by trial decoding, which is async and not possible in this sync API.
+    //
+    // TODO: cover all sizes — add an async decode path (decodeV2ImageAuto() in
+    // decodeImageV2.ts already does width/height/subsampling auto-detection via the
+    // optional jpeg-js dep) and have the callers in api.ts (getImage) and
+    // p2p/session.ts await it, OR pass the real dimensions in from event metadata.
+    if (data.subarray(0, V2_PREFIX.length).toString("latin1") === V2_PREFIX) {
+      const spliced = spliceV2Image(data, 288, 176, "4:2:0");
+      return spliced ?? data;
+    }
     const header = data.subarray(0, 12).toString();
     if (header === "eufysecurity") {
       const serialNumber = data.subarray(13, 29).toString();


### PR DESCRIPTION
 Decode v6 v2_eufysecurity: event/push images (keyless)
  
  **Problem**

  eufy app v6 changed how event/push thumbnails are delivered. Instead of a plain JPEG URL, pic_url now resolves to a v2_eufysecurity:<serial>:<pkt>:<binary> payload.
  The existing decodeImage() only handles the legacy eufysecurity (v1) magic, so v2 payloads fall through untouched — MIME detection fails and no image is shown.

  **Root cause**

  Despite the name, these images aren't meaningfully encrypted. The v2 format is head-only obfuscation: only the first ~286 bytes (the JPEG header — SOI + APP0 + DQT 
  + SOF + start of DHT) are AES-GCM scrambled. Everything from the standard baseline DC-chrominance Huffman marker (FF C4 00 1F 01) onward — the rest of the DHT, the 
  SOS, the entire entropy-coded scan, and the EOI — is plaintext, standard JPEG.

  The scrambled header only ever held the quantization tables (cosmetic) and the image dimensions. So no key is needed — we discard the scrambled head and splice a
  freshly built standard JPEG header onto the plaintext tail.

  **What this PR adds**

  - src/http/decodeImageV2.ts (new):
    - spliceV2Image(blob, w, h, ss) — reconstruct a viewable JPEG at known dimensions.
    - buildJpegPrefix(w, h, ss) — build a standard baseline header from a canonical template.
    - decodeV2ImageAuto(blob) — full auto-detection (no key, no metadata): recovers width (the value that minimises row-to-row shear), height (largest frame before
  the embedded EOI is hit), and chroma subsampling (lowest colour-spread). Returns { jpeg, width, height, subsampling, lowConfidence }. Uses the optional jpeg-js
  dependency for trial decoding.
  - src/http/utils.ts: decodeImage() now handles the v2_eufysecurity prefix.
  - docs/v2_image_format.md: protocol documentation + diagram of the format and decode method.
  - package.json: jpeg-js added as an optional dependency.

  **Coverage & limitation**

  decodeImage() is synchronous, so it reconstructs at a fixed 288×176 4:2:0 — the standard event-thumbnail size, which covers the common push-notification image.
  Images of other sizes (full-resolution snapshots, 4:4:4) will shear in this sync path, because their true dimensions can only be recovered via async trial decoding.

  A TODO in the code documents the follow-up: expose an async decode path that awaits decodeV2ImageAuto() from the api.ts/p2p/session.ts callers (or pass dimensions
  from event metadata) to cover all sizes.


#890 