### PR TITLE
fix(outdoor-pt): restore S340 (T8170) disable→app sync broken by #873

### DIFF
--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -7443,12 +7443,28 @@ export class Station extends TypedEmitter<StationEvents> {
         }
       );
     } else if (device.isOutdoorPanAndTiltCamera()) {
-      // Outdoor pan/tilt cams (eufyCam S4 / T8172 etc.) behind a HomeBase 3
-      // silently drop raw CMD_DEVS_SWITCH frames. Pcap comparison against
-      // the iOS Eufy app shows they accept the same wrapped envelope as
-      // INDOOR_PT_CAMERA_S350 — outer CMD_SET_PAYLOAD carrying inner
-      // CMD_INDOOR_ENABLE_PRIVACY_MODE_S350.
+      // Outdoor pan/tilt cams (type 48) cover both the S340 (T8170) and the
+      // S4 (T8172). They behave differently:
+      //  - S340: uses the legacy CMD_DEVS_SWITCH (1035) on/off path. The HB3
+      //    processes this raw command, updates param 1035 in the cloud, and
+      //    pushes the change to the Eufy app (so the app reflects it live).
+      //  - S4:   only reacts to the wrapped CMD_INDOOR_ENABLE_PRIVACY_MODE_S350
+      //    (6250) envelope (see #710 / #873); it ignores raw 1035 frames.
+      // Sending both keeps both models working: each cam acts on the command
+      // it understands and ignores the other.
       param_value = value === true ? 0 : 1;
+      this.p2pSession.sendCommandWithIntString(
+        {
+          commandType: CommandType.CMD_DEVS_SWITCH,
+          value: param_value,
+          valueSub: device.getChannel(),
+          strValue: this.rawStation.member.admin_user_id,
+          channel: device.getChannel(),
+        },
+        {
+          property: propertyData,
+        }
+      );
       this.p2pSession.sendCommandWithStringPayload(
         {
           commandType: CommandType.CMD_SET_PAYLOAD,

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -7131,6 +7131,9 @@ export const DeviceProperties: Properties = {
     ...GenericDeviceProperties,
     [PropertyName.DeviceWifiRSSI]: DeviceWifiRSSIProperty,
     [PropertyName.DeviceWifiSignalLevel]: DeviceWifiSignalLevelProperty,
+    // S340 exposes its on/off state via the legacy CMD_DEVS_SWITCH (1035) param,
+    // which is what the Eufy mobile app reads and writes. (The S4/T8172 uses the
+    // wrapped 6250 privacy param instead.)
     [PropertyName.DeviceEnabled]: DeviceEnabledSoloProperty,
     [PropertyName.DeviceBattery]: DeviceBatteryProperty,
     [PropertyName.DeviceBatteryTemp]: DeviceBatteryTempProperty,


### PR DESCRIPTION
## Problem

Disabling a **SoloCam S340 (T8170)** from a third-party client (Home Assistant
via eufy-security-ws) no longer syncs the disabled state to the **Eufy mobile
app**. This worked before v4.0.0.

Fixes #916.

## Root cause

PR #873 added an `isOutdoorPanAndTiltCamera()` branch to `enableDevice()` that
routes **all** `OUTDOOR_PT_CAMERA` (device type 48) devices through the wrapped
`CMD_INDOOR_ENABLE_PRIVACY_MODE_S350` (param `6250`) envelope, replacing the
legacy raw `CMD_DEVS_SWITCH` (param `1035`) command.

That change was validated on the **eufyCam S4 (T8172)**, but the **S340 (T8170)**
shares the same device type while still relying on the legacy `1035` path. With
only the `6250` envelope sent:

- the S340 toggles physically, but
- the HomeBase 3 never updates param `1035` and never pushes the change to the
  Eufy app, so the app's enabled state goes stale.

## Fix

In `enableDevice()`, for `OUTDOOR_PT_CAMERA` send **both** P2P commands:

- raw `CMD_DEVS_SWITCH` (`1035`) — the HB3 processes it, updates `1035`, and
  pushes to the app (S340 / pre-v4 behavior).
- the `CMD_INDOOR_ENABLE_PRIVACY_MODE_S350` (`6250`) envelope — kept for the S4.

Each model acts on the command it understands and ignores the other, so both
keep working.

Also restores the `DeviceEnabled` read mapping for type 48 to
`DeviceEnabledSoloProperty` (`1035`) — the param the S340 and the Eufy app
actually read/write.

## Testing

Verified on a HomeBase 3 + SoloCam S340 (T8170) via eufy-security-ws:

- Disable from HA → camera turns off **and the Eufy app reflects "Turned off"
  live** (no app restart needed).
- Re-enable from HA → camera turns on and the app updates.

## Note for maintainer

Type 48 covers two physically different models (S340/T8170 and S4/T8172) that
share one property mapping. The write path is purely additive and safe for both.
The single shared `DeviceEnabled` read mapping can only point at one param; this
PR points it at `1035` (what the S340 and the app use). If S4 users depend on the
`6250` read mapping from #873, a model-specific (T8170 vs T8172) split may be
preferable — happy to adjust.
