### PR TITLE
Add T8501 (Eufy Solo Smart Lock D20) lock/unlock support (V12 protocol)

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -2229,6 +2229,16 @@ export class Device extends TypedEmitter<DeviceEvents> {
     return DeviceType.LOCK_WIFI_NO_FINGER == type;
   }
 
+  static isLockWifiT8501(type: number, serialnumber: string): boolean {
+    // Eufy Solo Smart Lock D20 (T8501). It reports device_type LOCK_WIFI_NO_FINGER (53) but
+    // does NOT speak the legacy wifi-lock protocol: lock/unlock, get-params and status only
+    // work over the "V12" lock protocol (getLockV12P2PCommand, the same family as the R10/R20
+    // locks, T8503/T8504). Verified against real hardware (legacy and smart-lock P2P commands
+    // get no response; V12 returns ERROR_PPCS_SUCCESSFUL and actuates the bolt). Disambiguated
+    // by model/serial prefix, the same way T8510P/T8520P are split out from plain LOCK_WIFI.
+    return DeviceType.LOCK_WIFI_NO_FINGER == type && serialnumber.startsWith("T8501");
+  }
+
   static isLockWifiT8531(type: number): boolean {
     return DeviceType.LOCK_8531 == type;
   }
@@ -2730,6 +2740,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
   public isLockWifiNoFinger(): boolean {
     return Device.isLockWifiNoFinger(this.rawDevice.device_type);
+  }
+
+  public isLockWifiT8501(): boolean {
+    return Device.isLockWifiT8501(this.rawDevice.device_type, this.rawDevice.device_sn);
   }
 
   public isLockWifiR10(): boolean {

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -8466,7 +8466,7 @@ export class Station extends TypedEmitter<StationEvents> {
           property: propertyData,
         }
       );
-    } else if (device.isLockWifi() || device.isLockWifiNoFinger()) {
+    } else if ((device.isLockWifi() || device.isLockWifiNoFinger()) && !device.isLockWifiT8501()) {
       const nestedPayload: LockAdvancedOnOffRequestPayload = {
         shortUserId: this.rawStation.member.short_user_id,
         slOperation: value === true ? 1 : 0,
@@ -8521,7 +8521,7 @@ export class Station extends TypedEmitter<StationEvents> {
         device: device.getSerial(),
         admin_user_id: this.rawStation.member.admin_user_id,
       });
-    } else if (device.isLockWifiR10() || device.isLockWifiR20()) {
+    } else if (device.isLockWifiR10() || device.isLockWifiR20() || device.isLockWifiT8501()) {
       const command = getLockV12P2PCommand(
         this.rawStation.station_sn,
         this.rawStation.member.admin_user_id,
@@ -17983,7 +17983,11 @@ export class Station extends TypedEmitter<StationEvents> {
         Lock.encodeCmdSmartLockGetParams(this.rawStation.member.admin_user_id)
       );
       this.p2pSession.sendCommandWithStringPayload(command.payload);
-    } else if (Device.isLockWifiR10(this.getDeviceType()) || Device.isLockWifiR20(this.getDeviceType())) {
+    } else if (
+      Device.isLockWifiR10(this.getDeviceType()) ||
+      Device.isLockWifiR20(this.getDeviceType()) ||
+      Device.isLockWifiT8501(this.getDeviceType(), this.getSerial())
+    ) {
       rootHTTPLogger.debug(`Station lock v12 send get lock parameters command`, { stationSN: this.getSerial() });
       const command = getLockV12P2PCommand(
         this.rawStation.station_sn,
@@ -18019,7 +18023,11 @@ export class Station extends TypedEmitter<StationEvents> {
         Lock.encodeCmdSmartLockStatus(this.rawStation.member.admin_user_id)
       );
       this.p2pSession.sendCommandWithStringPayload(command.payload);
-    } else if (Device.isLockWifiR10(this.getDeviceType()) || Device.isLockWifiR20(this.getDeviceType())) {
+    } else if (
+      Device.isLockWifiR10(this.getDeviceType()) ||
+      Device.isLockWifiR20(this.getDeviceType()) ||
+      Device.isLockWifiT8501(this.getDeviceType(), this.getSerial())
+    ) {
       rootHTTPLogger.debug(`Station lock v12 send get lock status command`, { stationSN: this.getSerial() });
       const command = getLockV12P2PCommand(
         this.rawStation.station_sn,


### PR DESCRIPTION
## Summary

The **Eufy Solo Smart Lock D20 (T8501)** is already detected as a lock and its state reads correctly, but **lock/unlock commands are silently ignored**. Root cause: it's routed to the **legacy** wifi-lock P2P protocol, but the T8501 only responds to the **"V12"** lock protocol (`getLockV12P2PCommand`, the same family as the R10/R20 retrofit locks). Routing it through V12 makes lock/unlock work. No new `DeviceType`/`DeviceProperties` entries are needed.

Closes #226.

## Device facts (captured from a live unit)

| Field | Value |
|---|---|
| `device_type` | **53** (`LOCK_WIFI_NO_FINGER`) |
| `device_model` | `T8501` |
| serial prefix | `T8501…` (it is its own station) |
| hardwareVersion | `P0` |
| softwareVersion | `1.0.4.0` |
| `Device.isLock(53)` | already `true` |
| state (`locked` / `lockStatus` / `battery`) | reads fine |

State arrives over **MQTT** (smart-lock message, eventType 770 lockState / 261 unlock / 264 lock), which is why state has always worked even though every command was being dropped.

## Root cause

`Station.lockDevice()` dispatched device_type 53 via `isLockWifiNoFinger()` into the **legacy** branch (`getLockP2PCommand`, `P2P_ON_OFF_LOCK`). The `"P0"` hardware superficially resembles the modern smart-lock family, but **neither** the legacy **nor** the smart-lock (`getSmartLockP2PCommand`) protocol gets any response from this device — only **`getLockV12P2PCommand`** does.

### Evidence (redacted P2P traces)

```
# legacy (as shipped):  no response
getLockP2PCommand cmd 1961 (P2P_ON_OFF_LOCK)          -> lock does not move
P2P_QUERY_STATUS_IN_LOCK (1955)                       -> return_code -133 (ERROR_COMMAND_TIMEOUT)

# smart-lock:  no response
getSmartLockP2PCommand cmd 6018 / handshake 6016,6012 -> no P2P response

# V12:  WORKS
getLockV12P2PCommand handshake 6016,6012              -> return_code 0 (ERROR_PPCS_SUCCESSFUL), command_type 1930
  UNLOCK -> locked=false, lockStatus 4->3, MQTT unlock event (261)
  LOCK   -> locked=true,  lockStatus 3->4, MQTT lock  event (264)
```

Both directions physically actuate the bolt and the state reflects back.

## What changed

- **`src/http/device.ts`** — add `Device.isLockWifiT8501(type, serial)` (device_type 53 **and** serial starts with `T8501`, so other type-53 devices are unaffected — mirrors the existing `T8510P`/`T8520P` serial-prefix split), plus the instance wrapper.
- **`src/http/station.ts`** — route T8501 through the **V12** branch in `lockDevice`, `getLockParameters` and `getLockStatus`; exclude it from the legacy `isLockWifi()/isLockWifiNoFinger()` branch. The RSA lock public key is still fetched (V12 needs it), so the public-key gate is unchanged.

Builds clean (`tsc`); the change follows the existing file style.

> Known-incomplete (not needed for lock/unlock): `calibrateLock()` and a few other per-feature dispatch sites still route device_type 53 down the legacy path. Only lock/unlock + connect-time params/status were changed here; the rest can follow the same `isLockWifiT8501()` routing if desired.

## Verification

- **Library standalone:** UNLOCK then LOCK both return `return_code 0`, the bolt physically moves, `locked`/`lockStatus` update, and MQTT lock/unlock events fire.
- **End-to-end via Home Assistant** (`fuatakgun/eufy_security` → `eufy-security-ws` 3.0.1 → patched client): `lock.unlock` / `lock.lock` actuate the real D20 and Home Assistant reflects the state.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
