### PR TITLE
Reverse engineered new ESL codec + MQTT client to add C32 support - this unlocks eufy's new system

### DIFF
--- a/examples/mega-login.ts
+++ b/examples/mega-login.ts
@@ -1,0 +1,30 @@
+/**
+ * Standalone demo of the eufy "mega" cloud API (app-name: eufy_mega).
+ * Logs in, then fetches the house list. Requires env vars:
+ *   EUFY_EMAIL, EUFY_PW, optional EUFY_REGION (eu|us, default eu)
+ *
+ *   EUFY_EMAIL=you@example.com EUFY_PW=secret node examples/mega-login.ts
+ */
+import { MegaApi } from "../src/http/mega.ts";
+
+const email = process.env.EUFY_EMAIL;
+const password = process.env.EUFY_PW;
+if (!email || !password) {
+    console.error("Set EUFY_EMAIL and EUFY_PW environment variables.");
+    process.exit(2);
+}
+const region = (process.env.EUFY_REGION as "eu" | "us") ?? "eu";
+
+const api = new MegaApi({ region, log: (m, ...a) => console.log("[mega]", m, ...a) });
+await api.keyExchange();
+const profile = await api.login(email, password);
+console.log("logged in:", { user_id: profile.user_id, email: (profile as Record<string, unknown>).email });
+
+// --- provision the legacy eufy_security MQTT client cert (lock command channel) ---
+try {
+    const iot = await api.registerIotMqtt();
+    console.log("registerIotMqtt keys:", Object.keys(iot));
+    console.log("registerIotMqtt:", JSON.stringify(iot).slice(0, 1500));
+} catch (e) {
+    console.error("registerIotMqtt error:", (e as Error).message);
+}

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -62,6 +62,7 @@ import {
   VerfyCodeTypes,
 } from "./types";
 import { ParameterHelper } from "./parameter";
+import { MegaApi, LockMqttCredentials } from "./mega";
 import {
   encryptAPIData,
   decryptAPIData,
@@ -451,6 +452,47 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
      *
      */
     return this.headers.country!;
+  }
+
+  /**
+   * Provision (and cache) the eufy_security MQTT client certificate used by the FamiLock C32
+   * (T85L1 / device_type 211) command channel. The cert is long-lived, so it is persisted in
+   * {@link HTTPApiPersistentData} and reused across restarts — provisioning performs a full
+   * eufy "mega" passport login (the legacy session token is NOT accepted by the mega gateway),
+   * which the cloud rate-limits, so it must not run on every command. Returns cert+key ready
+   * for `EslClient`.
+   */
+  public async provisionEslLockCert(): Promise<LockMqttCredentials> {
+    const cached = this.persistentData.eslLockCert;
+    if (cached) {
+      return { ...cached, caCert: "" };
+    }
+    const country = (this.getCountry() || "US").toUpperCase();
+    // The mega data domain is resolved per-account; US/CA/MX route to the US region, all others to EU.
+    const region: "us" | "eu" = ["US", "CA", "MX"].includes(country) ? "us" : "eu";
+    const mega = new MegaApi({
+      region,
+      country,
+      log: (msg) => rootHTTPLogger.debug(`[mega/esl] ${msg}`),
+    });
+    await mega.keyExchange();
+    await mega.login(this.username, this.password);
+    const cred = await mega.provisionLockMqttCert();
+    this.persistentData.eslLockCert = {
+      cert: cred.cert,
+      key: cred.key,
+      endpoint: cred.endpoint,
+      thingName: cred.thingName,
+      userId: cred.userId,
+      certificateId: cred.certificateId,
+    };
+    // persistentData is serialized by the consumer on its normal save cycle; caching here
+    // means the long-lived cert is reused on the next restart instead of re-logging in.
+    rootHTTPLogger.info("Provisioned ESL lock MQTT certificate", {
+      thingName: cred.thingName,
+      endpoint: cred.endpoint,
+    });
+    return cred;
   }
 
   public setLanguage(language: string): void {

--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -2198,6 +2198,7 @@ export class Device extends TypedEmitter<DeviceEvents> {
       Device.isLockWifiT85V0(type) ||
       Device.isLockWifiT8502(type) ||
       Device.isLockWifiT85L0(type) ||
+      Device.isLockWifiT85L1(type) ||
       Device.isLockWifiT8531(type) ||
       Device.isLockWifiT85D0(type) ||
       Device.isLockWifiT85P0(type)
@@ -2298,6 +2299,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
   static isLockWifiT85L0(type: number): boolean {
     return DeviceType.LOCK_85L0 == type;
+  }
+
+  static isLockWifiT85L1(type: number): boolean {
+    return DeviceType.LOCK_85L1 == type;
   }
 
   static isBatteryDoorbell1(type: number): boolean {
@@ -2778,6 +2783,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
 
   public isLockWifiT85L0(): boolean {
     return Device.isLockWifiT85L0(this.rawDevice.device_type);
+  }
+
+  public isLockWifiT85L1(): boolean {
+    return Device.isLockWifiT85L1(this.rawDevice.device_type);
   }
 
   public isLockWifiT85P0(): boolean {
@@ -4719,7 +4728,13 @@ export class Lock extends Device {
       this.emit("low battery", this, newValue as boolean);
     } else if (
       (metadata.key === CommandType.CMD_DOORLOCK_GET_STATE ||
-        metadata.key === CommandType.CMD_SMARTLOCK_QUERY_STATUS) &&
+        metadata.key === CommandType.CMD_SMARTLOCK_QUERY_STATUS ||
+        // FamiLock family (T85L0/T85L1) reports live state via the `lockStatus` property
+        // (key 6000) rather than the legacy status command keys; keep `locked` in sync with it
+        // so HA reflects reality — notably the auto-lock that re-locks the latch a few seconds
+        // after a remote unlock (this is a latch lock, not a deadbolt; auto-lock is its normal
+        // "lock" path). lockStatus 4 = Locked.
+        metadata.name === PropertyName.DeviceLockStatus) &&
       ((oldValue !== undefined && ((oldValue === 4 && newValue !== 4) || (oldValue !== 4 && newValue === 4))) ||
         oldValue === undefined)
     ) {
@@ -6036,7 +6051,13 @@ export class DoorbellLock extends DoorbellCamera {
       this.emit("low battery", this, newValue as boolean);
     } else if (
       (metadata.key === CommandType.CMD_DOORLOCK_GET_STATE ||
-        metadata.key === CommandType.CMD_SMARTLOCK_QUERY_STATUS) &&
+        metadata.key === CommandType.CMD_SMARTLOCK_QUERY_STATUS ||
+        // FamiLock family (T85L0/T85L1) reports live state via the `lockStatus` property
+        // (key 6000) rather than the legacy status command keys; keep `locked` in sync with it
+        // so HA reflects reality — notably the auto-lock that re-locks the latch a few seconds
+        // after a remote unlock (this is a latch lock, not a deadbolt; auto-lock is its normal
+        // "lock" path). lockStatus 4 = Locked.
+        metadata.name === PropertyName.DeviceLockStatus) &&
       ((oldValue !== undefined && ((oldValue === 4 && newValue !== 4) || (oldValue !== 4 && newValue === 4))) ||
         oldValue === undefined)
     ) {

--- a/src/http/interfaces.ts
+++ b/src/http/interfaces.ts
@@ -153,6 +153,19 @@ export interface HTTPApiPersistentData {
   };
   clientPrivateKey: string;
   serverPublicKey: string;
+  /**
+   * Cached eufy_security MQTT client certificate for the FamiLock C32 (T85L1) ESL command
+   * channel, provisioned once via the mega cloud (the cert is long-lived). Persisting it
+   * avoids a fresh mega passport login on every restart/command (which is rate-limited).
+   */
+  eslLockCert?: {
+    cert: string;
+    key: string;
+    endpoint: string;
+    thingName: string;
+    userId: string;
+    certificateId: string;
+  };
 }
 
 export interface CaptchaOptions {

--- a/src/http/mega.ts
+++ b/src/http/mega.ts
@@ -1,0 +1,389 @@
+import { createECDH, ECDH, createHmac, createHash, createCipheriv, createDecipheriv, randomUUID, randomBytes } from "crypto";
+
+/**
+ * eufy "mega" cloud API client (app-name: `eufy_mega`).
+ *
+ * This is the newer Anker/eufy ecosystem used by Tuya-platform devices such as the
+ * FamiLock C32 (T85xx). Unlike the legacy eufy ecosystem implemented in {@link HTTPApi},
+ * every request to a mega host is signed and body-encrypted with the `algo_ecdh` scheme:
+ *
+ *  1. A one-time ECDH (P-256) key exchange establishes a per-session `securityKey`.
+ *     The exchange request itself is signed with a hard-coded, app-wide `presetKey`.
+ *  2. Subsequent request bodies are AES-128-CBC encrypted with the first 16 bytes of the
+ *     ECDH shared secret, and signed with HMAC-SHA256 keyed by the hex `securityKey`.
+ *
+ * The scheme (and the `presetKey` constant) were recovered from the eufy Security Android
+ * app's `com.anker.commonkit.aknetwork` layer and verified against live captures.
+ */
+
+/** App-wide preset key for the `eufy_mega` brand (AES-128 key via hex, HMAC key via ascii). */
+const PRESET_KEY = "2500a7d5617812f9d52515b2c8f20a3d";
+
+/** Fixed server public key the cloud holds the private half of; used for login password encryption. */
+const DEFAULT_SERVER_KEY =
+    "04c5c00c4f8d1197cc7c3167c52bf7acb054d722f0ef08dcd7e0883236e0d72a3868d9750cb47fa4619248f3d83f0f662671dadc6e2d31c2f41db0161651c7c076";
+
+const APP_NAME = "eufy_mega";
+
+export interface MegaDevice {
+    id: string;
+    sn: string;
+    name: string;
+    product_code: string;
+    local_key?: string;
+    [key: string]: unknown;
+}
+
+export interface MegaLoginResult {
+    auth_token: string;
+    user_id: string;
+    [key: string]: unknown;
+}
+
+/** Parsed lock command-channel MQTT credentials (see {@link MegaApi.provisionLockMqttCert}). */
+export interface LockMqttCredentials {
+    /** Client certificate PEM (CN `<user_id>-eufy_security`), for mutual-TLS to the broker. */
+    cert: string;
+    /** Client private key PEM. */
+    key: string;
+    /** Broker host, e.g. `security-mqtt-ie.anker.com`. */
+    endpoint: string;
+    /** AWS-IoT thing name (`<user_id>-eufy_security`). */
+    thingName: string;
+    userId: string;
+    /** Amazon Root CA PEM (the broker presents a public chain; included for completeness). */
+    caCert: string;
+    certificateId: string;
+}
+
+type Json = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// crypto helpers (mirror com.anker.commonkit.aknetwork.utils.EncryptUtil)
+// ---------------------------------------------------------------------------
+
+const uuidHex = (): string => randomUUID().replace(/-/g, "");
+
+/** Base64( IV(16) ‖ AES-CBC-PKCS7(plain, key, IV) ) — key length selects AES-128/256. */
+const aesCbcEncryptIvPrepended = (plain: Buffer, key: Buffer): string => {
+    const iv = randomBytes(16);
+    const algo = key.length === 32 ? "aes-256-cbc" : "aes-128-cbc";
+    const cipher = createCipheriv(algo, key, iv);
+    return Buffer.concat([iv, cipher.update(plain), cipher.final()]).toString("base64");
+};
+
+/** Inverse of {@link aesCbcEncryptIvPrepended}: IV is the first 16 bytes of the payload. */
+const aesCbcDecryptIvPrepended = (b64: string, key: Buffer): Buffer => {
+    const raw = Buffer.from(b64, "base64");
+    const iv = raw.subarray(0, 16);
+    const algo = key.length === 32 ? "aes-256-cbc" : "aes-128-cbc";
+    const decipher = createDecipheriv(algo, key, iv);
+    return Buffer.concat([decipher.update(raw.subarray(16)), decipher.final()]);
+};
+
+/** AES-CBC where the IV equals the first 16 bytes of the key (login-password style, no IV prepended). */
+const aesCbcKeyIv = (plain: Buffer, key: Buffer): string => {
+    const algo = key.length === 32 ? "aes-256-cbc" : "aes-128-cbc";
+    const cipher = createCipheriv(algo, key, key.subarray(0, 16));
+    return Buffer.concat([cipher.update(plain), cipher.final()]).toString("base64");
+};
+
+const hmacHex = (keyAscii: string, msg: string): string =>
+    createHmac("sha256", Buffer.from(keyAscii, "utf8")).update(msg, "utf8").digest("hex");
+
+/**
+ * Holds the ECDH keypair + negotiated server key for one host group (e.g. *.eufy.com mega).
+ * One keypair is reused across all hosts that share the same `securityKey`.
+ */
+class MegaSession {
+    private readonly ecdh: ECDH = createECDH("prime256v1");
+    /** Negotiated after key exchange; falls back to the fixed key (login-only flows). */
+    public serverPublicKey: string = DEFAULT_SERVER_KEY;
+    public exchanged = false;
+
+    constructor() {
+        this.ecdh.generateKeys();
+    }
+
+    /** Uncompressed app public key (130 hex chars, `04‖X‖Y`). */
+    appPublicKeyHex(): string {
+        return this.ecdh.getPublicKey("hex");
+    }
+
+    /** Full ECDH shared secret (32 bytes) against the current server key. */
+    private sharedSecret(): Buffer {
+        return this.ecdh.computeSecret(Buffer.from(this.serverPublicKey, "hex"));
+    }
+
+    /** 16-byte body-encryption key (first half of the shared secret). */
+    bodyKey(): Buffer {
+        return this.sharedSecret().subarray(0, 16);
+    }
+
+    /** 32-hex-char security key (hex of {@link bodyKey}); used as the HMAC ascii key. */
+    securityKeyHex(): string {
+        return this.bodyKey().toString("hex");
+    }
+}
+
+export interface MegaApiOptions {
+    region?: "eu" | "us";
+    country?: string;
+    language?: string;
+    /** Stable per-install device id; reuse the value the app registered to keep the session trusted. */
+    openudid?: string;
+    log?: (msg: string, ...args: unknown[]) => void;
+}
+
+export class MegaApi {
+    private readonly region: "eu" | "us";
+    private readonly country: string;
+    private readonly language: string;
+    private readonly log: (msg: string, ...args: unknown[]) => void;
+    private readonly openudid: string;
+    private readonly keyIdent = uuidHex();
+    private readonly session = new MegaSession();
+
+    private authToken: string | null = null;
+    private userId: string | null = null;
+    private gtoken: string | null = null;
+
+    constructor(opts: MegaApiOptions = {}) {
+        this.region = opts.region ?? "eu";
+        this.country = opts.country ?? "US";
+        this.language = opts.language ?? "en";
+        this.openudid = opts.openudid ?? randomBytes(8).toString("hex");
+        this.log = opts.log ?? (() => {});
+    }
+
+    private host(service: string): string {
+        return `https://app-${service}-${this.region}-pr.eufy.com`;
+    }
+
+    private commonHeaders(): Record<string, string> {
+        // Mirror the app's headers EXACTLY — the session token is bound to this device/locale
+        // fingerprint, so mismatches yield "token not exist". The app sends both hyphen and
+        // underscore variants of several headers.
+        const h: Record<string, string> = {
+            "app-name": APP_NAME,
+            "content-type": "application/json",
+            country: this.country,
+            language: this.language,
+            openudid: this.openudid,
+            "model-type": "PHONE",
+            "os-type": "android",
+            os_type: "android",
+            "os-version": "35",
+            os_version: "35",
+            "phone-model": "ONEPLUS A5010",
+            phone_model: "ONEPLUS A5010",
+            "app-version": "6.0.51_26722",
+            app_version: "6.0.51_26722",
+            ab_code: "AE",
+            "test-flag": "false",
+            accept: "application/json",
+            "accept-charset": "UTF-8",
+            "x-replay-info": "replay",
+            "x-encryption-info": "algo_ecdh",
+            "x-key-ident": this.keyIdent,
+            "user-agent": "ktor-client",
+        };
+        if (this.authToken) {
+            h["x-auth-token"] = this.authToken;
+            h["authorization"] = this.authToken;
+        }
+        if (this.gtoken) h["gtoken"] = this.gtoken;
+        return h;
+    }
+
+    /**
+     * One-time ECDH key exchange. The request is signed with the {@link PRESET_KEY};
+     * the response carries the server public key (encrypted with the same preset key).
+     */
+    async keyExchange(): Promise<void> {
+        const clientPublicKey = aesCbcEncryptIvPrepended(
+            Buffer.from(this.session.appPublicKeyHex(), "utf8"),
+            Buffer.from(PRESET_KEY, "hex"),
+        );
+        const ts = Math.floor(Date.now() / 1000).toString();
+        const once = uuidHex();
+        const signature = hmacHex(PRESET_KEY, `${ts}+${once}+${clientPublicKey}`);
+
+        const url = `${this.host("openapi")}/openapi/oauth/key/exchange`;
+        const res = await fetch(url, {
+            method: "POST",
+            headers: {
+                ...this.commonHeaders(),
+                "x-request-ts": ts,
+                "x-request-once": once,
+                "x-signature": signature,
+            },
+            body: JSON.stringify({ client_public_key: clientPublicKey }),
+        });
+        const body = (await res.json()) as { code: number; msg?: string; data?: { server_public_key: string } };
+        this.log(`keyExchange -> code=${body.code} msg=${body.msg ?? ""}`);
+        if (body.code !== 0 || !body.data?.server_public_key) {
+            throw new Error(`key exchange failed: ${JSON.stringify(body)}`);
+        }
+        const serverPubHex = aesCbcDecryptIvPrepended(body.data.server_public_key, Buffer.from(PRESET_KEY, "hex")).toString("utf8");
+        this.session.serverPublicKey = serverPubHex;
+        this.session.exchanged = true;
+        this.log(`keyExchange ok, securityKey=${this.session.securityKeyHex()}`);
+    }
+
+    /** Signed + body-encrypted request to a mega host. Returns the decrypted `data` payload. */
+    private async signedRequest(service: string, path: string, payload: Json | null, baseUrl?: string, extraHeaders?: Record<string, string>): Promise<unknown> {
+        if (!this.session.exchanged) throw new Error("keyExchange() must run first");
+        const ts = Math.floor(Date.now() / 1000).toString();
+        const once = uuidHex();
+        let encBody = "";
+        if (payload !== null) {
+            encBody = aesCbcEncryptIvPrepended(Buffer.from(JSON.stringify(payload), "utf8"), this.session.bodyKey());
+        }
+        const signMsg = encBody ? `${ts}+${once}+${encBody}` : `${ts}+${once}`;
+        const signature = hmacHex(this.session.securityKeyHex(), signMsg);
+
+        const res = await fetch(`${baseUrl ?? this.host(service)}${path}`, {
+            method: "POST",
+            headers: {
+                ...this.commonHeaders(),
+                "x-request-ts": ts,
+                "x-request-once": once,
+                "x-signature": signature,
+                ...extraHeaders,
+            },
+            body: encBody,
+        });
+        const text = await res.text();
+        let env: { code: number; msg?: string; data?: string; signature?: string };
+        try {
+            env = JSON.parse(text);
+        } catch {
+            throw new Error(`${path} -> HTTP ${res.status} non-JSON: ${text.slice(0, 200)}`);
+        }
+        this.log(`${path} -> code=${env.code} msg=${env.msg ?? ""}`);
+        if (env.code !== 0) throw new Error(`${path} failed: ${JSON.stringify(env).slice(0, 300)}`);
+        if (!env.data) return null;
+        const plain = aesCbcDecryptIvPrepended(env.data, this.session.bodyKey()).toString("utf8");
+        return JSON.parse(plain);
+    }
+
+    /**
+     * The account's A/B region group (e.g. "AE"). Returned by {@link getClientRealCode}.
+     * CRITICAL: this value MUST be sent as the `ab` field of the login body — without it the
+     * passport issues a token that every mega-gateway host rejects with 401 "token not exist".
+     */
+    async getClientRealCode(email: string): Promise<string> {
+        const data = (await this.signedRequest("passport", "/passport/get_client_real_code", { email })) as {
+            ab_code?: string;
+        };
+        return data?.ab_code ?? "";
+    }
+
+    /** Pre-login probe; also confirms the email is a registered/activated account. */
+    async validateEmail(email: string): Promise<{ status?: string; enc_text?: string; [k: string]: unknown }> {
+        return (await this.signedRequest("passport", "/passport/validate_email", { email })) as {
+            status?: string;
+            enc_text?: string;
+        };
+    }
+
+    /**
+     * Passport login. Mirrors NetworkConfigManager.login: email + ECDH-encrypted password.
+     *
+     * The `ab` (region group) field is mandatory: the token is only registered in the mega
+     * gateway's session store when login carries the account's ab_code. If not supplied it is
+     * resolved automatically via {@link getClientRealCode}.
+     */
+    async login(email: string, password: string, abCode?: string): Promise<MegaLoginResult> {
+        const ab = abCode ?? ((await this.getClientRealCode(email)) || "AE");
+        await this.validateEmail(email);
+
+        // password encryption: AES-256-CBC(password, key=ECDH(app, fixed-server-key), iv=key[:16])
+        const loginEcdh = createECDH("prime256v1");
+        loginEcdh.generateKeys();
+        const shared = loginEcdh.computeSecret(Buffer.from(DEFAULT_SERVER_KEY, "hex"));
+        const encPassword = aesCbcKeyIv(Buffer.from(password, "utf8"), shared);
+
+        const payload: Json = {
+            email,
+            password: encPassword,
+            client_secret_info: { public_key: loginEcdh.getPublicKey("hex") },
+            ab,
+        };
+        const data = (await this.signedRequest("passport", "/passport/login", payload)) as MegaLoginResult;
+        this.authToken = data.auth_token;
+        this.userId = data.user_id;
+        if (this.userId) {
+            this.gtoken = createHash("md5").update(Buffer.from(this.userId, "utf8")).digest("hex");
+        }
+        this.log(`login ok user_id=${this.userId} ab=${ab}`);
+        return data;
+    }
+
+    /**
+     * Fetch thing-model definitions (actions/properties) for the given product codes.
+     * For the C32 use `["T85L1"]`. Note: this returns the product *model*, not instances.
+     */
+    async getThingsList(productCodes: string[]): Promise<unknown[]> {
+        const data = (await this.signedRequest("things", "/app/things/get_things_list", { product_codes: productCodes })) as { things_list?: unknown[] };
+        return data.things_list ?? [];
+    }
+
+    /** AWS-IoT MQTT credentials (mutual-TLS cert + key + endpoint) for the command/event channel. */
+    async getUserMqttInfo(): Promise<Record<string, unknown>> {
+        return (await this.signedRequest("devicemanage", "/app/devicemanage/get_user_mqtt_info", {})) as Record<string, unknown>;
+    }
+
+    /**
+     * Inject an existing eufy_security ecosystem session (auth token + user id) — e.g. from the
+     * main HTTPApi login. Required for endpoints that authenticate against the eufy_security
+     * backend (such as {@link registerIotMqtt}) rather than the mega passport.
+     */
+    setSession(authToken: string, userId: string): void {
+        this.authToken = authToken;
+        this.userId = userId;
+        this.gtoken = createHash("md5").update(Buffer.from(userId, "utf8")).digest("hex");
+    }
+
+    /**
+     * Provision the legacy eufy_security MQTT client certificate used for the lock command
+     * channel (broker security-mqtt-ie.anker.com, mutual-TLS). Returns the per-user client
+     * cert + private key (CN `<user_id>-eufy_security`). Host is mega-<region>-pr.eufy.com.
+     * Requires a eufy_security session token (see {@link setSession}).
+     */
+    async registerIotMqtt(): Promise<Record<string, unknown>> {
+        const baseUrl = `https://mega-${this.region}-pr.eufy.com`;
+        // the shared mega gateway dispatches this endpoint to the right backend by app-tab/category
+        return (await this.signedRequest("", "/app/mqtt/register/iot", {}, baseUrl, { "app-tab": "eufy_security", category: "eufy_security" })) as Record<string, unknown>;
+    }
+
+    /**
+     * Provision and parse the lock command-channel MQTT credentials in one call, returning a
+     * shape ready to hand to {@link EslClient}. Must be called after {@link login} (or
+     * {@link setSession}) so the request carries a registered eufy_security token.
+     */
+    async provisionLockMqttCert(): Promise<LockMqttCredentials> {
+        const r = (await this.registerIotMqtt()) as Record<string, string>;
+        return {
+            cert: r.certificate_pem,
+            key: r.private_key,
+            endpoint: r.endpoint_addr,
+            thingName: r.thing_name,
+            userId: r.user_id,
+            caCert: r.amazon_root_ca_1_pem,
+            certificateId: r.certificate_id,
+        };
+    }
+
+    /**
+     * Fetch the per-device secret keys (DSK) used to encrypt smart-lock commands.
+     * NOTE: this is OWNER-ONLY — a shared/member account receives code 20004
+     * ("Only the owner can change settings").
+     */
+    async getDskKeys(deviceSns: string[]): Promise<unknown> {
+        return this.signedRequest("devicerelation", "/app/devicerelation/get_dsk_keys", {
+            device_dsks: deviceSns.map((sn) => ({ device_sn: sn, invalid_dsk: "" })),
+        });
+    }
+}

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -141,6 +141,7 @@ import {
   AdvancedLockSetParamsTypeT8520,
 } from "../p2p/models";
 import { Device, DoorbellCamera, Lock, SmartSafe } from "./device";
+import { EslClient, EslEventListener } from "../mqtt/esl-client";
 import {
   encodeLockPayload,
   encryptLockAESData,
@@ -906,6 +907,12 @@ export class Station extends TypedEmitter<StationEvents> {
   }
 
   public isP2PConnectableDevice(): boolean {
+    // The FamiLock T85L1 is a "supported" device but has no P2P station — it rides the ESL
+    // MQTT channel (see lockDeviceEsl), so attempting a P2P connection only spams getDSKKeys
+    // failures. Skip it here, the same gate stock uses to avoid connecting unsupported devices.
+    if (Device.isLockWifiT85L1(this.getDeviceType())) {
+      return false;
+    }
     if (Device.isSmartTrack(this.getDeviceType()) || (!Device.isSupported(this.getDeviceType()) && !this.isStation())) {
       if (!Device.isSupported(this.getDeviceType()) && !this.isStation()) {
         rootHTTPLogger.debug("Station not supported, no connection over p2p will be initiated", {
@@ -8577,6 +8584,10 @@ export class Station extends TypedEmitter<StationEvents> {
       this.p2pSession.sendCommandWithStringPayload(command.payload, {
         property: propertyData,
       });
+    } else if (device.isLockWifiT85L1()) {
+      // FamiLock C32 (T85L1 / type 211): no P2P station — commands ride the eufy_security
+      // MQTT broker (mutual-TLS). Provision the cert lazily and actuate over the ESL channel.
+      this.lockDeviceEsl(device, value, propertyData);
     } else {
       throw new NotSupportedError("This functionality is not implemented or supported by this device", {
         context: {
@@ -8587,6 +8598,94 @@ export class Station extends TypedEmitter<StationEvents> {
         },
       });
     }
+  }
+
+  /**
+   * Persistent subscriber for the FamiLock's async event frames (state changes incl. auto-lock).
+   * Keyed by device serial; started lazily on the first ESL command so it shares the same cert.
+   */
+  private eslEventListeners: Map<string, EslEventListener> = new Map();
+
+  /**
+   * Ensure a persistent ESL event listener is running for this lock so its live state (a remote
+   * unlock and the auto-lock that re-locks it ~10s later) flows back into `lockStatus`/`locked`.
+   * The FamiLock has no P2P feed and isn't seen by the standard MQTT push service, so this is the
+   * only path that keeps HA in sync with reality.
+   */
+  private ensureEslEventListener(device: Device, cred: { cert: string; key: string; userId: string }): void {
+    const sn = device.getSerial();
+    // ponytail: one persistent listener per lock, kept for the process lifetime (it auto-reconnects).
+    // Wire stop() into Station teardown if device churn ever matters; not needed for a fixed home setup.
+    if (this.eslEventListeners.has(sn)) return;
+    const listener = new EslEventListener({
+      cert: cred.cert,
+      key: cred.key,
+      userId: cred.userId,
+      deviceSn: sn,
+      productCode: device.getModel(),
+      onEvent: (ev) => {
+        if (ev.status !== undefined) {
+          // lockStatus update triggers Lock.handlePropertyChange, which syncs `locked`.
+          device.updateProperty(PropertyName.DeviceLockStatus, ev.status);
+        }
+      },
+      log: (msg) => rootHTTPLogger.debug(`[esl-evt] ${msg}`),
+    });
+    this.eslEventListeners.set(sn, listener);
+    listener.start();
+  }
+
+  /**
+   * Actuate the FamiLock C32 (T85L1) over its ESL MQTT command channel. The lock accepts only
+   * ONE command per MQTT session (a second command on the same connection is rejected and the
+   * session then goes silent), so a fresh client is connected and torn down for each command.
+   */
+  private lockDeviceEsl(device: Device, value: boolean, propertyData: PropertyData): void {
+    (async () => {
+      const cred = await this.api.provisionEslLockCert();
+      this.ensureEslEventListener(device, cred);
+      const client = new EslClient({
+        cert: cred.cert,
+        key: cred.key,
+        userId: cred.userId,
+        ownerId: this.rawStation.member.admin_user_id,
+        deviceSn: device.getSerial(),
+        productCode: device.getModel(),
+        // operator name/slot recorded in the lock's event log (a4/a5). The eufy app sends the
+        // constant "Autohome"/1 for app-initiated (non-keypad) operations; the lock treats
+        // these as an audit label and does not validate the name.
+        shortUserId: Number.parseInt(this.rawStation.member.short_user_id) || 1,
+        log: (msg) => rootHTTPLogger.debug(`[esl] ${msg}`),
+      });
+      try {
+        await client.connect();
+        const res = value ? await client.lock() : await client.unlock();
+        rootHTTPLogger.debug("Station lock device (ESL) - command result", {
+          station: this.getSerial(),
+          device: device.getSerial(),
+          value,
+          ok: res.ok,
+          body: res.body,
+        });
+        if (res.ok) {
+          device.updateProperty(propertyData.name, value, true);
+        }
+        this.emit("command result", this, {
+          channel: device.getChannel(),
+          command_type: CommandType.P2P_ON_OFF_LOCK,
+          return_code: res.ok ? 0 : -1,
+          customData: { property: propertyData },
+        } as CommandResult);
+      } finally {
+        client.disconnect();
+      }
+    })().catch((err) => {
+      rootHTTPLogger.error("Station lock device (ESL) - failed", {
+        station: this.getSerial(),
+        device: device.getSerial(),
+        error: getError(ensureError(err)),
+      });
+    });
   }
 
   public setStationSwitchModeWithAccessCode(value: boolean): void {

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -102,6 +102,7 @@ export enum DeviceType {
   LOCK_85L0 = 201,
   LOCK_85V0 = 203,
   LOCK_85P0 = 209, //T85P0
+  LOCK_85L1 = 211, //T85L1 FamiLock C32 (ESL/MQTT command channel)
   NVR_S4_MAX = 300, //T8N00
   CAMERA_POE_S4 = 301, //T8E00
   WALL_LIGHT_CAM_81A0 = 10005,
@@ -7985,6 +7986,29 @@ export const DeviceProperties: Properties = {
     [PropertyName.DevicePersonName]: DevicePersonNameProperty,
   },
   [DeviceType.LOCK_85L0]: {
+    ...GenericDeviceProperties,
+    [PropertyName.DeviceBattery]: DeviceBatteryLockProperty,
+    [PropertyName.DeviceLocked]: DeviceLockedProperty,
+    [PropertyName.DeviceLockStatus]: DeviceAdvancedLockStatusProperty,
+    [PropertyName.DeviceAutoLock]: DeviceAutoLockProperty,
+    [PropertyName.DeviceAutoLockTimer]: DeviceAutoLockTimerProperty,
+    [PropertyName.DeviceAutoLockSchedule]: DeviceAutoLockScheduleProperty,
+    [PropertyName.DeviceAutoLockScheduleStartTime]: DeviceAutoLockScheduleStartTimeProperty,
+    [PropertyName.DeviceAutoLockScheduleEndTime]: DeviceAutoLockScheduleEndTimeProperty,
+    [PropertyName.DeviceOneTouchLocking]: DeviceOneTouchLockingProperty,
+    [PropertyName.DeviceWrongTryProtection]: DeviceWrongTryProtectionProperty,
+    [PropertyName.DeviceWrongTryAttempts]: DeviceWrongTryAttemptsProperty,
+    [PropertyName.DeviceWrongTryLockdownTime]: DeviceWrongTryLockdownTimeProperty,
+    [PropertyName.DeviceScramblePasscode]: DeviceScramblePasscodeProperty,
+    [PropertyName.DeviceSound]: DeviceSoundProperty,
+    [PropertyName.DeviceNotification]: DeviceNotificationSmartLockProperty,
+    [PropertyName.DeviceNotificationUnlocked]: DeviceNotificationUnlockedSmartLockProperty,
+    [PropertyName.DeviceNotificationLocked]: DeviceNotificationLockedSmartLockProperty,
+    [PropertyName.DeviceLowBatteryAlert]: DeviceLowBatteryAlertProperty,
+    [PropertyName.DeviceLockEventOrigin]: DeviceLockEventOriginProperty,
+    [PropertyName.DevicePersonName]: DevicePersonNameProperty,
+  },
+  [DeviceType.LOCK_85L1]: {
     ...GenericDeviceProperties,
     [PropertyName.DeviceBattery]: DeviceBatteryLockProperty,
     [PropertyName.DeviceLocked]: DeviceLockedProperty,

--- a/src/mqtt/esl-client.ts
+++ b/src/mqtt/esl-client.ts
@@ -1,0 +1,199 @@
+/**
+ * Minimal MQTT client for the eufy_security lock command channel (FamiLock C32 / T85L1).
+ *
+ * Connects to the legacy Anker broker over mutual-TLS, publishes ESL commands on
+ * `cmd/eufy_security/<product>/<sn>/req`, and resolves with the lock's reply from `.../res`.
+ * The client cert/key are provisioned via MegaApi.registerIotMqtt() (or extracted from the app
+ * keystore integration_eufy_security.bks, password "eufy_password").
+ */
+import mqtt, { MqttClient } from "mqtt";
+import { randomBytes } from "crypto";
+import { buildLockPayload, decodeResponse, decodeEvent, EslEvent, EslOpcode, ESL_API_ONOFF } from "./esl";
+
+const BROKER_HOST = "security-mqtt-ie.anker.com";
+const BROKER_PORT = 8883;
+
+/** Extract the inner `lock_payload` hex from a raw `/res` MQTT envelope, or undefined. */
+function extractLockPayload(payload: Buffer): string | undefined {
+    try {
+        const env = JSON.parse(payload.toString("utf8"));
+        const pl = typeof env.payload === "string" ? JSON.parse(env.payload) : env.payload;
+        const inner = JSON.parse(Buffer.from(pl?.trans ?? "", "base64").toString("utf8"));
+        const lp = inner?.payload?.lock_payload;
+        return typeof lp === "string" ? lp : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export interface EslClientOptions {
+    /** Client certificate PEM (CN `<userId>-eufy_security`). */
+    cert: string | Buffer;
+    /** Client private key PEM. */
+    key: string | Buffer;
+    /** Our (member or owner) user id — used to form a unique MQTT clientId. */
+    userId: string;
+    /** Device owner's user id (the key/TLV are derived from this). */
+    ownerId: string;
+    deviceSn: string;
+    /** Product code prefix in the topic, e.g. "T85L1". */
+    productCode: string;
+    /** Operator name recorded in the lock's event log (defaults to "Autohome"). */
+    userName?: string;
+    /** Operator slot id recorded in the lock's event log (defaults to 1). */
+    shortUserId?: number;
+    log?: (msg: string, ...args: unknown[]) => void;
+}
+
+export class EslClient {
+    private client?: MqttClient;
+    private readonly opts: EslClientOptions;
+    private readonly reqTopic: string;
+    private readonly resTopic: string;
+    private readonly log: (msg: string, ...args: unknown[]) => void;
+    // The lock allows only one command per connection (a fresh client is used per command),
+    // so a single in-flight waiter suffices. The header msgType byte is a constant (0x23), not
+    // a counter, so it can't disambiguate concurrent commands anyway.
+    private pending?: (hex: string) => void;
+
+    constructor(opts: EslClientOptions) {
+        this.opts = opts;
+        this.log = opts.log ?? (() => {});
+        this.reqTopic = `cmd/eufy_security/${opts.productCode}/${opts.deviceSn}/req`;
+        this.resTopic = `cmd/eufy_security/${opts.productCode}/${opts.deviceSn}/res`;
+    }
+
+    async connect(): Promise<void> {
+        const clientId = `android-eufy_security-${this.opts.userId}-${randomBytes(4).toString("hex")}-${Math.floor(Date.now() / 1000)}`;
+        this.client = mqtt.connect(`mqtts://${BROKER_HOST}:${BROKER_PORT}`, {
+            cert: this.opts.cert,
+            key: this.opts.key,
+            clientId,
+            protocolVersion: 4,
+            reconnectPeriod: 0,
+            connectTimeout: 15000,
+            // broker presents a public GoDaddy cert -> standard verification works
+        });
+        await new Promise<void>((resolve, reject) => {
+            this.client!.on("connect", () => {
+                this.client!.subscribe(this.resTopic, { qos: 1 }, (err) => (err ? reject(err) : resolve()));
+            });
+            this.client!.on("error", reject);
+        });
+        this.client.on("message", (topic, payload) => this.onMessage(topic, payload));
+        this.log(`ESL connected, clientId=${clientId}`);
+    }
+
+    private onMessage(topic: string, payload: Buffer): void {
+        if (!topic.endsWith("/res")) return;
+        const lp = extractLockPayload(payload);
+        if (!lp) return;
+        // Ignore async event frames here (handled by EslEventListener); only resolve command ACKs.
+        if (decodeEvent(lp)) return;
+        const waiter = this.pending;
+        if (waiter) {
+            this.pending = undefined;
+            waiter(lp);
+        }
+    }
+
+    /** Send a command and wait for the lock's reply (resolves with the decoded ACK, or rejects on timeout). */
+    private async send(opcode: EslOpcode, api: number, includeUser: boolean, timeoutMs = 10000): Promise<{ ok: boolean; body: string }> {
+        if (!this.client) throw new Error("connect() first");
+        const ts = Math.floor(Date.now() / 1000);
+        const lockPayload = buildLockPayload({
+            accountId: this.opts.ownerId, deviceSn: this.opts.deviceSn, ts, opcode, includeUser,
+            userName: this.opts.userName, shortUserId: this.opts.shortUserId,
+        });
+        const trans = Buffer.from(JSON.stringify({
+            cmd: 1940, mChannel: 0, mValue3: 0,
+            payload: { apiCommand: api, lock_payload: lockPayload, seq_num: ts, time: ts },
+        })).toString("base64");
+        const msg = JSON.stringify({
+            head: { version: "1.0.0.1", client_id: this.client.options.clientId, sess_id: randomBytes(2).toString("hex"),
+                msg_seq: 2, seed: randomBytes(16).toString("hex"), timestamp: ts, cmd_status: 2, cmd: 9, sign_code: 0 },
+            payload: JSON.stringify({ account_id: this.opts.ownerId, device_sn: this.opts.deviceSn, trans }),
+        });
+
+        const replyHex = await new Promise<string>((resolve, reject) => {
+            const t = setTimeout(() => { this.pending = undefined; reject(new Error("ESL command timeout")); }, timeoutMs);
+            this.pending = (hex) => { clearTimeout(t); resolve(hex); };
+            this.client!.publish(this.reqTopic, msg, { qos: 1 }, (err) => { if (err) { clearTimeout(t); reject(err); } });
+        });
+        const decoded = decodeResponse(replyHex, this.opts.ownerId, this.opts.deviceSn, ts);
+        return { ok: decoded.ok, body: decoded.body.toString("hex") };
+    }
+
+    unlock(): Promise<{ ok: boolean; body: string }> { return this.send(EslOpcode.Unlock, ESL_API_ONOFF, true); }
+    lock(): Promise<{ ok: boolean; body: string }> { return this.send(EslOpcode.Lock, ESL_API_ONOFF, true); }
+
+    disconnect(): void { this.client?.end(true); }
+}
+
+export interface EslEventListenerOptions {
+    cert: string | Buffer;
+    key: string | Buffer;
+    /** Our user id — used to form a unique MQTT clientId. */
+    userId: string;
+    deviceSn: string;
+    /** Product code prefix in the topic, e.g. "T85L1". */
+    productCode: string;
+    /** Called for each decoded async lock event (state changes incl. the auto-lock). */
+    onEvent: (event: EslEvent) => void;
+    log?: (msg: string, ...args: unknown[]) => void;
+}
+
+/**
+ * Persistent subscriber for the FamiLock's asynchronous event frames.
+ *
+ * The FamiLock has no P2P/station feed and the bridge's standard MQTT push service
+ * (eufylife.com) never sees it, so the lock's live state changes — a remote unlock and, a few
+ * seconds later, the auto-lock that re-locks the latch — are only observable as plaintext event
+ * frames the lock publishes on its `cmd/eufy_security/<product>/<sn>/res` topic. This keeps a
+ * long-lived mutual-TLS connection subscribed to that topic and decodes those frames so the
+ * device's `lockStatus`/`locked` properties stay in sync with reality. It auto-reconnects.
+ */
+export class EslEventListener {
+    private client?: MqttClient;
+    private readonly opts: EslEventListenerOptions;
+    private readonly resTopic: string;
+    private readonly log: (msg: string, ...args: unknown[]) => void;
+
+    constructor(opts: EslEventListenerOptions) {
+        this.opts = opts;
+        this.log = opts.log ?? (() => {});
+        this.resTopic = `cmd/eufy_security/${opts.productCode}/${opts.deviceSn}/res`;
+    }
+
+    start(): void {
+        const clientId = `android-eufy_security-${this.opts.userId}-evt-${randomBytes(4).toString("hex")}`;
+        this.client = mqtt.connect(`mqtts://${BROKER_HOST}:${BROKER_PORT}`, {
+            cert: this.opts.cert,
+            key: this.opts.key,
+            clientId,
+            protocolVersion: 4,
+            reconnectPeriod: 5000,
+            connectTimeout: 15000,
+        });
+        this.client.on("connect", () => {
+            this.client!.subscribe(this.resTopic, { qos: 1 }, (err) =>
+                this.log(err ? `ESL event listener subscribe error: ${err.message}` : `ESL event listener subscribed (${this.resTopic})`)
+            );
+        });
+        this.client.on("message", (_topic, payload) => {
+            const lp = extractLockPayload(payload);
+            if (!lp) return;
+            const ev = decodeEvent(lp);
+            if (ev) {
+                this.log(`ESL event: status=${ev.status} a1=${ev.a1} a3=${ev.a3}`);
+                this.opts.onEvent(ev);
+            }
+        });
+        this.client.on("error", (err) => this.log(`ESL event listener error: ${err.message}`));
+    }
+
+    stop(): void {
+        this.client?.end(true);
+        this.client = undefined;
+    }
+}

--- a/src/mqtt/esl.test.ts
+++ b/src/mqtt/esl.test.ts
@@ -1,0 +1,34 @@
+import { buildLockPayload, decodeEvent, EslOpcode } from "./esl";
+
+// Golden vectors captured live from a FamiLock C32 (T85L1) the lock acknowledged with `00`.
+const OWNER = "99ec80cbf1daa7199af932aa4dd246a867aceb89";
+const SN = "T85L1P10260602AA";
+
+describe("ESL codec", () => {
+    test("buildLockPayload reproduces a verified unlock command byte-for-byte", () => {
+        const hex = buildLockPayload({
+            accountId: OWNER,
+            deviceSn: SN,
+            ts: 1782727921,
+            opcode: EslOpcode.Unlock,
+            includeUser: true,
+            userName: "Autohome",
+            shortUserId: 1,
+        });
+        expect(hex).toBe(
+            "ff096a000300024023409d33d5cffe39e97fca140df45face8265ab25290c26b052f61ac16092a367e66f6831" +
+                "8412a7602203097ac5e2618840d588381ef78b36115146d3abdc34f68f8abb43915407d407c40e88f68002af90" +
+                "7f08b2314e4574d0f381e76d280c04fff"
+        );
+    });
+
+    test("decodeEvent reads lock status from plaintext event frames", () => {
+        // a2 = 03 -> Unlocked, 04 -> Locked
+        expect(decodeEvent("FF091400030102004A00A10163A20103A3010168")?.status).toBe(3);
+        expect(decodeEvent("FF091400030102004A00A10163A20104A301016F")?.status).toBe(4);
+    });
+
+    test("decodeEvent ignores command-response frames (byte[5] !== 0x01)", () => {
+        expect(decodeEvent("FF091A000300024823CFF4E70AD1C651D2A6A982A57D8F014A55")).toBeNull();
+    });
+});

--- a/src/mqtt/esl.ts
+++ b/src/mqtt/esl.ts
@@ -1,0 +1,193 @@
+/**
+ * ESL (eufy smart lock) command codec for the newer Wi-Fi FamiLock family — reverse-engineered
+ * for the C32 (T85L1, device_type 211) which rides the legacy eufy_security MQTT broker
+ * (security-mqtt-ie.anker.com:8883, mutual-TLS) rather than the P2P/station path.
+ *
+ * The scheme has NO session handshake and NO per-device secret: the AES key is simply the
+ * tail of the owner account id plus the command's Unix timestamp (which is also sent in
+ * cleartext, so the lock reconstructs the same key). Verified byte-for-byte against live
+ * captures. See project notes for the full derivation.
+ *
+ *   key       = ascii(accountId[-12:]) ++ BE32(unixTs)            (16 bytes, AES-128)
+ *   iv        = ascii(deviceSn)                                   (16 bytes)
+ *   payload   = header(9) ++ AES-128-CBC-PKCS7(tlv) ++ checksum(1)
+ *   header    = FF 09 <totalLen> 00 03 00 02 <dir> <msgType>     dir 0x40=req/0x48=res, msgType 0x23
+ *   checksum  = XOR of all preceding bytes (header ++ ciphertext)
+ *   tlv       = a1:BE32(ts) reversed | a2:accountId | a3:opcode | (unlock: a4:user, a5:BE16 uid)
+ *               zero-filled to a 16-byte boundary, then PKCS7.
+ */
+import { createCipheriv, createDecipheriv } from "crypto";
+
+export const EslOpcode = { Lock: 0x00, Unlock: 0x01 } as const;
+export type EslOpcode = (typeof EslOpcode)[keyof typeof EslOpcode];
+
+export const EslDir = { Request: 0x40, Response: 0x48 } as const;
+export type EslDir = (typeof EslDir)[keyof typeof EslDir];
+
+/**
+ * Header byte[8] — a FIXED message-type byte for the on/off lock command, NOT a rolling
+ * counter. Every live member-app command (lock and unlock) carries 0x23 here; the lock
+ * rejects any other value with a `01` reply (verified: 0x31/0x55 → reject/ignore, 0x23 → 00).
+ * The lock echoes it unchanged in its `/res` frame.
+ */
+export const ESL_MSG_TYPE_ONOFF = 0x23;
+
+/**
+ * The on/off lock command (lock and unlock; lock vs unlock is selected by the a3 opcode,
+ * with the operator a4/a5 TLVs included). Verified against a live member-app unlock capture
+ * that the lock acknowledged with a `00` success reply.
+ */
+export const ESL_API_ONOFF = 6018;
+
+function tlv(tag: number, val: Buffer): Buffer {
+    return Buffer.concat([Buffer.from([tag, val.length]), val]);
+}
+
+function pkcs7Pad(data: Buffer, block = 16): Buffer {
+    const pad = block - (data.length % block) || block;
+    return Buffer.concat([data, Buffer.alloc(pad, pad)]);
+}
+
+function pkcs7Unpad(data: Buffer): Buffer {
+    const pad = data[data.length - 1];
+    if (pad < 1 || pad > 16 || pad > data.length) return data;
+    return data.subarray(0, data.length - pad);
+}
+
+export interface EslCommandParams {
+    /** Device owner's user id (the lock derives the key from this; a member uses the owner id from the shared record). */
+    accountId: string;
+    /** Device serial, e.g. "T85L1P10260602AA" — also used as the AES IV. */
+    deviceSn: string;
+    /** Unix timestamp (seconds). Defaults to now. Travels in cleartext so the lock rebuilds the key. */
+    ts?: number;
+    opcode: EslOpcode;
+    /**
+     * Header byte[8] — the fixed on/off message-type byte (see {@link ESL_MSG_TYPE_ONOFF}),
+     * echoed unchanged in the lock's response. This is NOT a counter: the lock only accepts
+     * 0x23 for this command, so it should be left at its default.
+     */
+    msgType?: number;
+    /**
+     * Include the operator metadata TLVs (a4 userName, a5 shortUserId). Required by the on/off
+     * lock command for BOTH lock and unlock (the lock logs who operated it); omit for the
+     * read-only status query.
+     */
+    includeUser?: boolean;
+    /** Operator metadata (who/which slot); shown in lock events. */
+    userName?: string;
+    shortUserId?: number;
+}
+
+function deriveKey(accountId: string, ts: number): Buffer {
+    const prefix = Buffer.from(accountId.slice(-12), "ascii");
+    const tsb = Buffer.alloc(4);
+    tsb.writeUInt32BE(ts >>> 0);
+    return Buffer.concat([prefix, tsb]); // 16 bytes
+}
+
+/** Build the hex `lock_payload` for a request command (header + cipher + checksum). */
+export function buildLockPayload(p: EslCommandParams): string {
+    const ts = p.ts ?? Math.floor(Date.now() / 1000);
+    const msgType = p.msgType ?? ESL_MSG_TYPE_ONOFF;
+    const key = deriveKey(p.accountId, ts);
+    const iv = Buffer.from(p.deviceSn, "ascii");
+    const tsb = Buffer.alloc(4);
+    tsb.writeUInt32BE(ts >>> 0);
+
+    let body = Buffer.concat([
+        tlv(0xa1, Buffer.from(tsb).reverse()),
+        tlv(0xa2, Buffer.from(p.accountId, "ascii")),
+        tlv(0xa3, Buffer.from([p.opcode])),
+    ]);
+    if (p.includeUser ?? p.opcode === EslOpcode.Unlock) {
+        body = Buffer.concat([
+            body,
+            tlv(0xa4, Buffer.from(p.userName ?? "Autohome", "ascii")),
+            tlv(0xa5, (() => { const b = Buffer.alloc(2); b.writeUInt16BE(p.shortUserId ?? 1); return b; })()),
+        ]);
+    }
+    // Zero-fill to the next 16-byte boundary, THEN PKCS7-pad a full block — this matches the
+    // member app's on/off command byte-for-byte (verified against a live capture the lock
+    // acknowledged with 00). Removing the zero-fill produces a body the lock rejects.
+    if (body.length % 16) body = Buffer.concat([body, Buffer.alloc(16 - (body.length % 16))]);
+
+    const cipher = createCipheriv("aes-128-cbc", key, iv);
+    cipher.setAutoPadding(false);
+    const ct = Buffer.concat([cipher.update(pkcs7Pad(body)), cipher.final()]);
+
+    const total = 9 + ct.length + 1;
+    const header = Buffer.from([0xff, 0x09, total & 0xff, 0x00, 0x03, 0x00, 0x02, EslDir.Request, msgType & 0xff]);
+    const framed = Buffer.concat([header, ct]);
+    let chk = 0;
+    framed.forEach((b) => { chk ^= b; });
+    return Buffer.concat([framed, Buffer.from([chk])]).toString("hex");
+}
+
+export interface EslResponse {
+    dir: number;
+    counter: number;
+    /** Decrypted TLV body (PKCS7-stripped). First byte 0x00 = success/ACK. */
+    body: Buffer;
+    ok: boolean;
+}
+
+/**
+ * Decode a `/res` lock_payload. The reply reuses the *request* timestamp for its key
+ * (its own cleartext `time` field reads "0"), so pass the ts you sent.
+ */
+export function decodeResponse(lockPayloadHex: string, accountId: string, deviceSn: string, requestTs: number): EslResponse {
+    const b = Buffer.from(lockPayloadHex, "hex");
+    const header = b.subarray(0, 9);
+    const ct = b.subarray(9, b.length - 1);
+    const key = deriveKey(accountId, requestTs);
+    const iv = Buffer.from(deviceSn, "ascii");
+    const dec = createDecipheriv("aes-128-cbc", key, iv);
+    dec.setAutoPadding(false);
+    const pt = pkcs7Unpad(Buffer.concat([dec.update(ct), dec.final()]));
+    return { dir: header[7], counter: header[8], body: pt, ok: pt.length > 0 && pt[0] === 0x00 };
+}
+
+/**
+ * Lock-status values carried in an async event frame's `a2` TLV (and the `lockStatus`
+ * device property). 3 = Unlocked, 4 = Locked are the two we act on.
+ */
+export const EslLockStatus = { Unlocked: 0x03, Locked: 0x04 } as const;
+
+export interface EslEvent {
+    /** Lock status from the a2 TLV (3 = unlocked, 4 = locked). */
+    status?: number;
+    /** a1 TLV (operator/user id observed in events; semantics TBD — surfaced raw). */
+    a1?: number;
+    /** a3 TLV (event sub-type/origin; surfaced raw). */
+    a3?: number;
+}
+
+/**
+ * Decode an asynchronous lock EVENT frame (e.g. a remote unlock or the auto-lock that follows).
+ * Unlike command responses these are PLAINTEXT — no AES — and are distinguished by header
+ * byte[5] === 0x01 (command responses carry 0x00) with msgType 0x4A. Layout verified against
+ * live captures:
+ *   header(9) = FF 09 14 00 03 01 02 00 4A
+ *   body      = 00 | A1 01 <a1> | A2 01 <status> | A3 01 <a3> | checksum(1)
+ * Returns null if the frame is not a recognizable event (so command ACKs fall through).
+ */
+export function decodeEvent(lockPayloadHex: string): EslEvent | null {
+    const b = Buffer.from(lockPayloadHex, "hex");
+    if (b.length < 11 || b[0] !== 0xff || b[1] !== 0x09 || b[5] !== 0x01) return null;
+    const body = b.subarray(9, b.length - 1); // strip 9-byte header and trailing checksum
+    const ev: EslEvent = {};
+    let i = 1; // skip the leading status/result byte (0x00)
+    while (i + 2 <= body.length) {
+        const tag = body[i];
+        const len = body[i + 1];
+        const val = body.subarray(i + 2, i + 2 + len);
+        if (len === 1) {
+            if (tag === 0xa1) ev.a1 = val[0];
+            else if (tag === 0xa2) ev.status = val[0];
+            else if (tag === 0xa3) ev.a3 = val[0];
+        }
+        i += 2 + len;
+    }
+    return ev.status !== undefined ? ev : null;
+}


### PR DESCRIPTION
The [C32](https://www.eufy.com/products/t85l1111) (device_type 211) has no P2P and the standard mqtt push never sees it, so it never worked in the lib. wired it end to end:

- new esl codec + mqtt client for the lock command channel (security-mqtt-ie.anker.com, mutual-TLS). reverse engineered, verified byte for byte against live captures
- mega cloud login to provision the lock cert, cached in persistent data so we don't re-login on every command (the cloud rate limits it)
- device_type 211 mapped as a lock, routed to the esl path
- persistent event listener so lockStatus/locked track reality, incl the auto-lock that re-locks the latch a few seconds after unlock
- one test using the real captured vectors

tested live on a C32: lock/unlock + state sync work from Home Assistant via eufy-security-ws.
