### PR TITLE
Force reconnect on sustained consecutive aged-out commands

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -154,6 +154,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
   private readonly ESD_DISCONNECT_TIMEOUT = 30 * 1000;
   private readonly MAX_STREAM_DATA_WAIT = 5 * 1000;
   private readonly RESEND_NOT_ACKNOWLEDGED_COMMAND = 100;
+  private readonly MAX_CONSECUTIVE_AGED_OUT_COMMANDS = 3;
 
   private streamTimeouts = {
     streamDataWait: this.MAX_STREAM_DATA_WAIT,
@@ -184,6 +185,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
   private binded = false;
   private connected = false;
   private connecting = false;
+  private consecutiveAgedOutCommands = 0;
   private terminating = false;
   private p2pTurnHandshaking: {
     [host: string]: boolean;
@@ -317,6 +319,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
     let rsaKey: NodeRSA | null;
 
     this.connected = false;
+    this.consecutiveAgedOutCommands = 0;
     this.p2pTurnHandshaking = {};
     this.p2pTurnConfirmed = false;
     this.connecting = false;
@@ -1016,6 +1019,14 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
           return_code: ErrorCode.ERROR_CONNECT_TIMEOUT,
           customData: message.customData,
         } as CommandResult);
+        this.consecutiveAgedOutCommands++;
+        if (this.connected && this.consecutiveAgedOutCommands >= this.MAX_CONSECUTIVE_AGED_OUT_COMMANDS) {
+          rootP2PLogger.warn(
+            `${this.consecutiveAgedOutCommands} commands in a row aged out from send queue for station ${this.rawStation.station_sn} despite an apparently healthy heartbeat. Connection seems stale, forcing reconnect...`,
+            { stationSN: this.rawStation.station_sn }
+          );
+          this._disconnected();
+        }
         return;
       }
     } else {
@@ -1433,6 +1444,7 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
               this.sendQueuedMessage();
             } else {
               msg_state.acknowledged = true;
+              this.consecutiveAgedOutCommands = 0;
               msg_state.timeout = setTimeout(
                 () => {
                   //TODO: Retry command in these case?


### PR DESCRIPTION
## Summary
- Add `MAX_CONSECUTIVE_AGED_OUT_COMMANDS = 3` and a `consecutiveAgedOutCommands` counter to `P2PClientProtocol`.
- In the existing "command aged out" branch of `_sendCommand()`, increment the counter after the normal logging/emit. Once it reaches the threshold while the session still believes it's connected, log a warning and call `this._disconnected()`, forcing the same reconnect path the heartbeat-timeout uses.
- Reset the counter to 0 the moment any real (non-ping) command actually gets a transport ACK, so the trigger only fires on sustained, consecutive failures rather than one-off packet loss.
- Reset the counter in `_initialize()` so each new session starts clean.

This targets the gap described in https://github.com/bropat/eufy-security-ws/issues/539: a connection that looks alive by heartbeat (PING/PONG still round-tripping) but is structurally unable to deliver any real command will now self-detect and force a reconnect after 3 consecutive dropped commands, instead of silently rotting for hours.

Fixes https://github.com/bropat/eufy-security-ws/issues/539

## Test plan
- [ ] Manual reproduction of a stale-but-heartbeating connection and confirm reconnect is triggered after 3 consecutive aged-out commands
- [ ] Confirm normal command timeouts (non-consecutive) do not trigger a reconnect
