### PR TITLE
fix(http): enable livestream for T8426 dual-lens floodlight cameras

### DIFF
--- a/src/http/device.ts
+++ b/src/http/device.ts
@@ -2688,6 +2688,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
     return Device.isFloodLightT8425(this.rawDevice.device_type);
   }
 
+  public isFloodLightT8426(): boolean {
+    return Device.isFloodLightT8426(this.rawDevice.device_type);
+  }
+
   public isWallLightCam(): boolean {
     return Device.isWallLightCam(this.rawDevice.device_type);
   }

--- a/src/http/station.ts
+++ b/src/http/station.ts
@@ -7712,6 +7712,7 @@ export class Station extends TypedEmitter<StationEvents> {
     } else if (
       device.isOutdoorPanAndTiltCamera() ||
       device.isFloodLightT8425() ||
+      device.isFloodLightT8426() ||
       (device.isBatteryDoorbellDualE340() && !this.isStationMiniBaseChime()) ||
       ((device.isIndoorPTCameraE30() || device.isIndoorCameraBase()) && this.isDeviceControlledByHomeBase())
     ) {


### PR DESCRIPTION
### What & why

Fixes #948 — the **T8426 dual-lens floodlight camera** (`FLOODLIGHT_CAMERA_8426`,
device type 87) never streams: `startLivestream()` resolves but the camera sends
no media and the P2P session times out after 5s with zero bytes.

Root cause: the T8426 is a floodlight (`isFloodLight(87) === true`) but matches
no earlier branch in `startLivestream()`, so it falls through to the generic
floodlight branch ("CMD_DOORBELL_SET_PAYLOAD (3)"), whose payload omits
`camera_type` / `entrytype`. Its sibling **T8425** uses the richer branch **"(1)"**
payload (`camera_type: 0`, `entrytype: 0`, `accountId`) and works. This routes
the T8426 through the same branch.

### Change

- `device.ts`: add instance helper `isFloodLightT8426()` (mirrors
  `isFloodLightT8425()`; the static `Device.isFloodLightT8426()` already existed).
- `station.ts`: include `device.isFloodLightT8426()` in the branch-1 condition of
  `startLivestream()`.

```diff
     } else if (
       device.isOutdoorPanAndTiltCamera() ||
       device.isFloodLightT8425() ||
+      device.isFloodLightT8426() ||
       (device.isBatteryDoorbellDualE340() && !this.isStationMiniBaseChime()) ||
       ((device.isIndoorPTCameraE30() || device.isIndoorCameraBase()) && this.isDeviceControlledByHomeBase())
     ) {
```

### Verification

Tested on **4×** T8426 (sw `1.2.1.0`). Before: 0 bytes + 5s timeout. After: all
four start **both lenses** (`1920x1080` + `2560x1440` H264), ~1.3 MB video +
~53 KB audio in ~18s, first bytes `00000001 67 …` (valid H264 SPS). Live 1080p
playback confirmed end-to-end.

- `npm run build:ts` — clean
- `npx prettier --check src/http/station.ts src/http/device.ts` — clean

### Notes

I understand the library is in stopgap/deprecation mode; this is a minimal
one-line routing fix so these cameras keep working on the current backend. No
behavioural change for any other device.
