### PR TITLE
Retry v6 push registration after identity rejection

### DIFF
--- a/src/http/__test__/megaApiPushSelector.test.tsx
+++ b/src/http/__test__/megaApiPushSelector.test.tsx
@@ -1,4 +1,4 @@
-import { MegaHTTPApi } from "../megaApi";
+import { MegaHTTPApi, megaLoginHash } from "../megaApi";
 
 jest.mock("../../logging", () => {
   const stub = { error: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), trace: jest.fn() };
@@ -13,13 +13,30 @@ jest.mock("../../logging", () => {
  *  - a v6 failure is swallowed (never propagates — legacy push is unaffected).
  */
 import { MegaTransition, MegaTransitionHost } from "../megaTransition";
+import { ResponseErrorCode } from "../types";
 
-type MegaStub = Pick<MegaHTTPApi, "hasValidSession" | "registerPushToken">;
+type MegaStub = Pick<MegaHTTPApi, "hasValidSession" | "registerPushToken" | "exportSession">;
+
+const openudid = "abc123".padEnd(32, "0");
+const session = {
+  ab: "US",
+  openudid,
+  cloud_token: "cloud-token",
+  cloud_token_expiration: 9999999999,
+  user_id: "user-id",
+};
+
+function withSession(mega: Pick<MegaHTTPApi, "hasValidSession" | "registerPushToken">): MegaStub {
+  return {
+    ...mega,
+    exportSession: jest.fn().mockReturnValue(session),
+  } as unknown as MegaStub;
+}
 
 function makeTransition(mega: MegaStub | undefined, opts?: { failGetMega?: boolean }) {
   const host = {
-    config: {},
-    persistentData: {},
+    config: { username: "user@example.com", password: "pass", country: "US" },
+    persistentData: { openudid },
     get api() {
       return undefined as never;
     },
@@ -36,46 +53,70 @@ function makeTransition(mega: MegaStub | undefined, opts?: { failGetMega?: boole
     if (opts?.failGetMega) throw new Error("init failed");
     return mega as MegaHTTPApi;
   });
-  return transition;
+  return { transition, host };
 }
 
 describe("MegaTransition.registerMegaPushToken (v6 best-effort)", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("registers when a valid v6 session exists (returns true)", async () => {
-    const mega = {
+    const mega = withSession({
       hasValidSession: () => true,
       registerPushToken: jest.fn().mockResolvedValue({ code: 0, msg: "ok" }),
-    };
-    const transition = makeTransition(mega);
+    });
+    const { transition, host } = makeTransition(mega);
     await expect(transition.registerMegaPushToken("tok")).resolves.toBe(true);
     expect(mega.registerPushToken).toHaveBeenCalledWith("tok");
+    expect(mega.exportSession).toHaveBeenCalledWith(megaLoginHash("user@example.com", "pass", openudid));
+    expect(host.persistentData.megaApi).toBe(session);
+    expect(host.writePersistentData).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once after a cached identity is rejected and persists the refreshed session", async () => {
+    const mega = withSession({
+      hasValidSession: () => true,
+      registerPushToken: jest
+        .fn()
+        .mockResolvedValueOnce({ code: ResponseErrorCode.CODE_NEED_NEGOTIATE_KEY, msg: "get identity error" })
+        .mockResolvedValueOnce({ code: 0, msg: "ok" }),
+    });
+    const { transition, host } = makeTransition(mega);
+    await expect(transition.registerMegaPushToken("tok")).resolves.toBe(true);
+    expect(mega.registerPushToken).toHaveBeenCalledTimes(2);
+    expect(mega.registerPushToken).toHaveBeenNthCalledWith(1, "tok");
+    expect(mega.registerPushToken).toHaveBeenNthCalledWith(2, "tok");
+    expect(host.persistentData.megaApi).toBe(session);
+    expect(host.writePersistentData).toHaveBeenCalledTimes(1);
   });
 
   it("skips register when there is no valid session (returns false)", async () => {
-    const mega = { hasValidSession: () => false, registerPushToken: jest.fn() };
-    const transition = makeTransition(mega);
+    const mega = withSession({ hasValidSession: () => false, registerPushToken: jest.fn() });
+    const { transition } = makeTransition(mega);
     await expect(transition.registerMegaPushToken("tok")).resolves.toBe(false);
     expect(mega.registerPushToken).not.toHaveBeenCalled();
+    expect(mega.exportSession).not.toHaveBeenCalled();
   });
 
   it("returns false (never throws) when the v6 register rejects (legacy push unaffected)", async () => {
-    const mega = { hasValidSession: () => true, registerPushToken: jest.fn().mockRejectedValue(new Error("401")) };
-    const transition = makeTransition(mega);
+    const mega = withSession({
+      hasValidSession: () => true,
+      registerPushToken: jest.fn().mockRejectedValue(new Error("401")),
+    });
+    const { transition } = makeTransition(mega);
     await expect(transition.registerMegaPushToken("tok")).resolves.toBe(false);
   });
 
   it("returns false (never throws) when getMegaApi itself fails", async () => {
-    const transition = makeTransition(undefined, { failGetMega: true });
+    const { transition } = makeTransition(undefined, { failGetMega: true });
     await expect(transition.registerMegaPushToken("tok")).resolves.toBe(false);
   });
 
   it("returns false on a non-zero register code", async () => {
-    const mega = {
+    const mega = withSession({
       hasValidSession: () => true,
       registerPushToken: jest.fn().mockResolvedValue({ code: 10000, msg: "fail" }),
-    };
-    const transition = makeTransition(mega);
+    });
+    const { transition } = makeTransition(mega);
     await expect(transition.registerMegaPushToken("tok")).resolves.toBe(false);
   });
 });

--- a/src/http/megaTransition.ts
+++ b/src/http/megaTransition.ts
@@ -138,8 +138,26 @@ export class MegaTransition {
         rootMainLogger.debug("v6 push: no valid mega session yet, skipping register (legacy still active)");
         return false;
       }
-      const result = await mega.registerPushToken(token);
+      const persistMegaSession = () => {
+        this.host.persistentData.megaApi = mega.exportSession(
+          megaLoginHash(this.host.config.username, this.host.config.password, this.host.persistentData.openudid)
+        );
+        this.host.writePersistentData();
+      };
+
+      let result = await mega.registerPushToken(token);
+      if (
+        result.code === ResponseErrorCode.CODE_NEED_NEGOTIATE_KEY ||
+        result.code === ResponseErrorCode.CODE_SIGNATURE_ERROR
+      ) {
+        rootMainLogger.info("v6 push: cached identity rejected, retrying register_push_token after re-key", {
+          code: result.code,
+          msg: result.msg,
+        });
+        result = await mega.registerPushToken(token);
+      }
       if (result.code === 0) {
+        persistMegaSession();
         rootMainLogger.info("v6 push: FCM token registered on the eufy_mega backend");
         return true;
       }


### PR DESCRIPTION
## Summary

Retry v6 `register_push_token` once when the cached Mega identity is rejected with `CODE_NEED_NEGOTIATE_KEY` or `CODE_SIGNATURE_ERROR`, then persist the refreshed Mega session after successful push registration.

## Why

When the cached v6/Mega identity is stale, `register_push_token` can fail even though the account still has a valid Mega auth session. `MegaHTTPApi.signedPost` already clears cached identities for these response codes, so retrying the push-token registration lets the second attempt perform a fresh key exchange and register successfully.

Persisting the session after a successful push registration keeps the refreshed identity available for later startups.

## Validation

- Focused Jest test:
  `npm test -- --runTestsByPath src/http/__test__/megaApiPushSelector.test.tsx --runInBand`
- Direct TypeScript compile:
  `./node_modules/.bin/tsc -p tsconfig.build.json`
- Prettier check:
  `./node_modules/.bin/prettier --check src/http/megaTransition.ts src/http/__test__/megaApiPushSelector.test.tsx`

Also validated against a real Home Assistant Eufy WS add-on setup where v6 push registration recovered and doorbell ring events began reaching the original ringing sensor after this patch.
