### PR TITLE
fix(p2p): auto-detect geometry for CMD_DATABASE_IMAGE, matching getImage()

### DIFF
--- a/src/p2p/session.ts
+++ b/src/p2p/session.ts
@@ -124,7 +124,7 @@ import {
 import { DskKeyResponse, ResultResponse, StationListResponse } from "../http/models";
 import { HTTPApi } from "../http/api";
 import { Device } from "../http/device";
-import { ParsePayload, decodeImage } from "../http/utils";
+import { ParsePayload, decodeImageAsync } from "../http/utils";
 import { TalkbackStream } from "./talkback";
 import { LivestreamError, TalkbackError, ensureError } from "../error";
 import { SmartSafeEvent } from "../push/types";
@@ -3798,11 +3798,24 @@ export class P2PClientProtocol extends TypedEmitter<P2PClientProtocolEvents> {
               message: str,
             });
             const image = parseJSON(str, rootP2PLogger) as CmdDatabaseImageResponse;
-            this.emit(
-              "image download",
-              image.file,
-              decodeImage(this.rawStation.p2p_did, Buffer.from(image.content, "base64"))
-            );
+            // Some devices (e.g. Video Doorbell Dual) send v2_eufysecurity-obfuscated
+            // JPEGs here too, not only the plain baseline JPEGs this command used to
+            // always carry, so this needs the same auto-detecting async decode
+            // api.ts's getImage() already uses. The old sync decodeImage() assumes a
+            // fixed 288x176 thumbnail geometry and shears/corrupts anything else
+            // (observed: a combined dual-lens frame reconstructed at ~2x its true
+            // width, and a wide single-lens night frame reconstructed transposed).
+            decodeImageAsync(this.rawStation.p2p_did, Buffer.from(image.content, "base64"))
+              .then((decoded) => {
+                this.emit("image download", image.file, decoded);
+              })
+              .catch((err) => {
+                const error = ensureError(err);
+                rootP2PLogger.error(`Handle DATA ${P2PDataType[message.dataType]} - CMD_DATABASE_IMAGE - Decode error`, {
+                  error: getError(error),
+                  stationSN: this.rawStation.station_sn,
+                });
+              });
           } catch (err) {
             const error = ensureError(err);
             rootP2PLogger.error(`Handle DATA ${P2PDataType[message.dataType]} - CMD_DATABASE_IMAGE - Error`, {


### PR DESCRIPTION
Mirrors getImage()'s use of decodeImageAsync — CMD_DATABASE_IMAGE still used the old synchronous decodeImage(), which assumes a fixed 288x176 4:2:0 geometry and shears/corrupts images of other sizes (observed on Video Doorbell Dual combined images). Covers the part of #924 that's still missing now that decodeImageAsync landed separately.