### PR TITLE
fix: expose speaker property for E340 doorbell

### DIFF
--- a/src/http/__test__/types.test.tsx
+++ b/src/http/__test__/types.test.tsx
@@ -1,0 +1,16 @@
+import { DeviceProperties, DeviceType, PropertyName } from "../types";
+
+describe("E340 device properties", () => {
+  it("exposes the writable speaker toggle supported by the official app", () => {
+    const speaker = DeviceProperties[DeviceType.BATTERY_DOORBELL_PLUS_E340][PropertyName.DeviceSpeaker];
+
+    expect(speaker).toEqual(
+      expect.objectContaining({
+        name: PropertyName.DeviceSpeaker,
+        type: "boolean",
+        readable: true,
+        writeable: true,
+      })
+    );
+  });
+});

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -6310,6 +6310,7 @@ export const DeviceProperties: Properties = {
     [PropertyName.DeviceRinging]: DeviceRingingProperty,
     [PropertyName.DevicePicture]: DevicePictureProperty,
     [PropertyName.DevicePictureUrl]: DevicePictureUrlProperty,
+    [PropertyName.DeviceSpeaker]: DeviceSpeakerProperty,
     [PropertyName.DeviceSpeakerVolume]: DeviceSpeakerVolumeIndoorFloodDoorbellProperty,
     [PropertyName.DeviceRingtoneVolume]: DeviceRingtoneVolumeBatteryDoorbellProperty,
     [PropertyName.DeviceMicrophone]: DeviceMicrophoneProperty,


### PR DESCRIPTION
## Summary

- expose the existing `DeviceSpeaker` property for `BATTERY_DOORBELL_PLUS_E340`
- allow consumers to toggle the E340 doorbell's binary device speaker setting
- add a regression test that verifies the property is present, boolean, and writable

## Why

The client already implements `DeviceSpeakerProperty` and the corresponding P2P command, but the E340 device profile did not include that property. As a result, consumers such as the Home Assistant Eufy integration could not expose the speaker switch for this model.

## Verification

- `npm run test -- --runInBand` — 19 suites / 370 tests passed
- `npm run format:check` — passed
- `npm run build` — passed
- runtime-verified with an E340: the generated switch updates the same speaker setting shown in the Eufy app in both directions