### PR TITLE
Accept HTTP-style success code from Mega/v6 API

### DIFF
--- a/src/http/__test__/responseCode.test.ts
+++ b/src/http/__test__/responseCode.test.ts
@@ -1,0 +1,16 @@
+import { isSuccessfulResponseCode } from "../api";
+import { ResponseErrorCode } from "../types";
+
+describe("isSuccessfulResponseCode", () => {
+  it("accepts the legacy success code", () => {
+    expect(isSuccessfulResponseCode(ResponseErrorCode.CODE_OK)).toBe(true);
+  });
+
+  it("accepts the HTTP-style success code returned by Mega/v6", () => {
+    expect(isSuccessfulResponseCode(200)).toBe(true);
+  });
+
+  it("rejects an error code", () => {
+    expect(isSuccessfulResponseCode(500)).toBe(false);
+  });
+});

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -86,6 +86,15 @@ import { rootHTTPLogger } from "../logging";
 
 type pThrottledFunction = <F extends AnyFunction>(function_: F) => ThrottledFunction<F>;
 
+/**
+ * Eufy's APIs use both the legacy application status code 0 and the HTTP-style
+ * status code 200 for successful responses.  The Mega/v6 backend currently
+ * returns 200 for several endpoints, so both values must be accepted.
+ */
+export function isSuccessfulResponseCode(code: number): boolean {
+  return code === ResponseErrorCode.CODE_OK || code === 200;
+}
+
 export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
   private static apiDomainBase = "https://extend.eufylife.com";
 
@@ -251,7 +260,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     });
 
     const result: ResultResponse = response.body as ResultResponse;
-    if (result.code == ResponseErrorCode.CODE_OK) {
+    if (isSuccessfulResponseCode(result.code)) {
       return `https://${result.data.domain}`;
     }
     throw new ApiBaseLoadError("Error identifying API base from cloud", {
@@ -558,7 +567,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
         if (response.status == 200) {
           const result: ResultResponse = response.data;
           if (result.data !== undefined) {
-            if (result.code == ResponseErrorCode.CODE_OK) {
+            if (isSuccessfulResponseCode(result.code)) {
               this.loginCompleted(result.data);
             } else if (result.code == ResponseErrorCode.CODE_NEED_VERIFY_CODE) {
               this.loginVerifyCode(result.data);
@@ -673,7 +682,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response != undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           rootHTTPLogger.info(`Requested verification code for 2FA`);
           return true;
         } else {
@@ -703,7 +712,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
         });
         if (response.status == 200) {
           const result: ResultResponse = response.data;
-          if (result.code == ResponseErrorCode.CODE_OK) {
+          if (isSuccessfulResponseCode(result.code)) {
             if (result.data && result.data.list) {
               return result.data.list;
             }
@@ -740,7 +749,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
       rootHTTPLogger.debug("Add trust device - Response trust device", { verifyCode: verifyCode, data: response.data });
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           rootHTTPLogger.info(`2FA authentication successfully done. Device trusted.`);
           const trusted_devices = await this.listTrustDevice();
           trusted_devices.forEach((trusted_device: TrustDevice) => {
@@ -788,7 +797,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response != undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == 0) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const stationList = this.decryptAPIData(result.data) as Array<StationListResponse>;
             rootHTTPLogger.debug("Decrypted station list data", stationList);
@@ -828,7 +837,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response != undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == 0) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const deviceList = this.decryptAPIData(result.data) as Array<DeviceListResponse>;
             rootHTTPLogger.debug("Decrypted device list data: %s", JSON.stringify(deviceList, null, 2));
@@ -986,7 +995,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == 0) {
+        if (isSuccessfulResponseCode(result.code)) {
           rootHTTPLogger.debug(`Check push token - Push token OK`);
           return true;
         } else {
@@ -1019,7 +1028,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == 0) {
+        if (isSuccessfulResponseCode(result.code)) {
           rootHTTPLogger.debug(`Register push token - Push token registered successfully`);
           return true;
         } else {
@@ -1072,7 +1081,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
       });
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == 0) {
+        if (isSuccessfulResponseCode(result.code)) {
           const dataresult = result.data;
           rootHTTPLogger.debug("Set parameter - New parameters set", { params: tmp_params, response: dataresult });
           return true;
@@ -1112,7 +1121,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const ciphers: Ciphers = {};
             const decrypted = this.decryptAPIData(result.data);
@@ -1155,7 +1164,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
         });
         if (response.status == 200) {
           const result: ResultResponse = response.data;
-          if (result.code == ResponseErrorCode.CODE_OK) {
+          if (isSuccessfulResponseCode(result.code)) {
             if (result.data) {
               const voices: Voices = {};
               result.data.forEach((voice: Voice) => {
@@ -1270,7 +1279,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
       rootHTTPLogger.debug(`${functionName} - Response:`, response.data);
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == 0) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const dataresult: Array<EventRecordResponse> = this.decryptAPIData(result.data);
             rootHTTPLogger.debug(`${functionName} - Decrypted data:`, dataresult);
@@ -1398,7 +1407,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data && typeof result.data === "string") {
             const invites: Invites = {};
             const decrypted = this.decryptAPIData(result.data);
@@ -1441,7 +1450,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           return true;
         } else {
           rootHTTPLogger.error("Confirm invites - Response code not ok", {
@@ -1476,7 +1485,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
           });
           if (response.status == 200) {
             const result: ResultResponse = response.data;
-            if (result.code == ResponseErrorCode.CODE_OK) {
+            if (isSuccessfulResponseCode(result.code)) {
               if (result.data) {
                 if (type === PublicKeyType.LOCK)
                   this.persistentData.device_public_keys[deviceSN] = result.data.public_key;
@@ -1555,7 +1564,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const entries: Array<SensorHistoryEntry> = result.data;
             return entries;
@@ -1592,7 +1601,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const houseDetail = this.decryptAPIData(result.data) as HouseDetail;
             rootHTTPLogger.debug("Get house detail - Decrypted house detail data", { details: houseDetail });
@@ -1627,7 +1636,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             rootHTTPLogger.debug("Get house list - houses", { houses: result.data });
             return result.data as Array<HouseListResponse>;
@@ -1660,7 +1669,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const houseInviteList = result.data as Array<HouseInviteListResponse>;
             rootHTTPLogger.debug("Get house invite list - House invite list data", houseInviteList);
@@ -1699,7 +1708,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           return true;
         } else {
           rootHTTPLogger.error("Confirm house invite - Response code not ok", {
@@ -1734,7 +1743,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           return true;
         } else {
           rootHTTPLogger.error("Send house invite - Response code not ok", {
@@ -1770,7 +1779,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
       });
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const profile = this.decryptAPIData(result.data) as PassportProfileResponse;
             rootHTTPLogger.debug("Get passport profile - Decrypted passport profile data", { profile: profile });
@@ -1812,7 +1821,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) return result.data as AddUserResponse;
         } else {
           rootHTTPLogger.error("Add user - Response code not ok", {
@@ -1850,7 +1859,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           return true;
         } else {
           rootHTTPLogger.error("Delete user - Response code not ok", {
@@ -1884,7 +1893,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
       });
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           if (result.data) {
             const usersResponse = result.data as UsersResponse;
             return usersResponse.user_list;
@@ -1962,7 +1971,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
       if (response !== undefined) {
         if (response.status == 200) {
           const result: ResultResponse = response.data;
-          if (result.code == ResponseErrorCode.CODE_OK) {
+          if (isSuccessfulResponseCode(result.code)) {
             return true;
           } else {
             rootHTTPLogger.error("Update user - Response code not ok", {
@@ -2064,7 +2073,7 @@ export class HTTPApi extends TypedEmitter<HTTPApiEvents> {
     if (response !== undefined) {
       if (response.status == 200) {
         const result: ResultResponse = response.data;
-        if (result.code == ResponseErrorCode.CODE_OK) {
+        if (isSuccessfulResponseCode(result.code)) {
           return true;
         } else {
           rootHTTPLogger.error("Add user - Response code not ok", {


### PR DESCRIPTION
## Problem

The Mega/v6 Eufy API currently returns `code: 200` for successful responses on several endpoints. The client only treated the legacy application success code (`0`) as successful, so valid responses were reported as failures. This can lead to profile loading failures, no houses being discovered, and subsequent device/push setup failures.

## Changes

- Centralize success-code handling in `isSuccessfulResponseCode`.
- Accept both the legacy `0` and HTTP-style `200` response codes throughout `HTTPApi`.
- Add unit coverage for both success codes and an error code.

## Validation

- `npm test -- --runInBand` (372 tests passed)
- `npm run build`

This is related to the Mega/v6 response-code behavior reported in #586.
